### PR TITLE
fix: resolve EBUSY error and Clean Architecture violations in project init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jumbo-ctx/cli",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "AI memory like and elephant for your coding agent.",
   "keywords": [
     "cli",

--- a/src/infrastructure/shared/persistence/migrations.config.ts
+++ b/src/infrastructure/shared/persistence/migrations.config.ts
@@ -1,0 +1,44 @@
+/**
+ * Centralized migrations configuration for all namespaces.
+ *
+ * This module provides a factory function to generate migration paths
+ * relative to the infrastructure directory. Used by both bootstrap.ts
+ * (for existing projects) and SqliteConnectionManager (for new databases).
+ */
+
+import path from "path";
+
+/**
+ * Configuration for namespace-based migrations.
+ * Each entry specifies a namespace and the path to its migration files.
+ */
+export interface NamespaceMigration {
+  namespace: string;
+  path: string;
+}
+
+/**
+ * Returns all namespace migrations with paths resolved relative to
+ * the provided infrastructure directory.
+ */
+export function getNamespaceMigrations(infrastructureDir: string): NamespaceMigration[] {
+  return [
+    // Work category
+    { namespace: "work/sessions", path: path.join(infrastructureDir, "work/sessions/migrations") },
+    { namespace: "work/goals", path: path.join(infrastructureDir, "work/goals/migrations") },
+    // Solution category
+    { namespace: "solution/decisions", path: path.join(infrastructureDir, "solution/decisions/migrations") },
+    { namespace: "solution/architecture", path: path.join(infrastructureDir, "solution/architecture/migrations") },
+    { namespace: "solution/components", path: path.join(infrastructureDir, "solution/components/migrations") },
+    { namespace: "solution/dependencies", path: path.join(infrastructureDir, "solution/dependencies/migrations") },
+    { namespace: "solution/guidelines", path: path.join(infrastructureDir, "solution/guidelines/migrations") },
+    { namespace: "solution/invariants", path: path.join(infrastructureDir, "solution/invariants/migrations") },
+    // Project knowledge category
+    { namespace: "project-knowledge/project", path: path.join(infrastructureDir, "project-knowledge/project/migrations") },
+    { namespace: "project-knowledge/audiences", path: path.join(infrastructureDir, "project-knowledge/audiences/migrations") },
+    { namespace: "project-knowledge/audience-pains", path: path.join(infrastructureDir, "project-knowledge/audience-pains/migrations") },
+    { namespace: "project-knowledge/value-propositions", path: path.join(infrastructureDir, "project-knowledge/value-propositions/migrations") },
+    // Relations category
+    { namespace: "relations", path: path.join(infrastructureDir, "relations/migrations") },
+  ];
+}

--- a/src/presentation/cli/project-knowledge/project/init/project.init.ts
+++ b/src/presentation/cli/project-knowledge/project/init/project.init.ts
@@ -1,13 +1,15 @@
 /**
  * CLI Command: jumbo project init
  *
- * Initializes a new Jumbo project by creating the .jumbo/ directory
- * and recording the initial ProjectInitialized event.
+ * Initializes a new Jumbo project by recording the initial ProjectInitialized event.
  */
 
-import path from "path";
 import { CommandMetadata } from "../../../shared/registry/CommandMetadata.js";
 import { ApplicationContainer } from "../../../../../infrastructure/composition/bootstrap.js";
+import { InitializeProjectCommand } from "../../../../../application/project-knowledge/project/init/InitializeProjectCommand.js";
+import { InitializeProjectCommandHandler } from "../../../../../application/project-knowledge/project/init/InitializeProjectCommandHandler.js";
+import { Renderer } from "../../../shared/rendering/Renderer.js";
+import { getBannerLines } from "../../../shared/components/AnimatedBanner.js";
 
 /**
  * Command metadata for auto-registration
@@ -43,26 +45,9 @@ export const metadata: CommandMetadata = {
   ],
   related: ["project update"]
 };
-import fs from "fs-extra";
-import { InitializeProjectCommandHandler } from "../../../../../application/project-knowledge/project/init/InitializeProjectCommandHandler.js";
-import { ProjectInitializedEventHandler } from "../../../../../application/project-knowledge/project/init/ProjectInitializedEventHandler.js";
-import { ProjectUpdatedEventHandler } from "../../../../../application/project-knowledge/project/update/ProjectUpdatedEventHandler.js";
-import { InitializeProjectCommand } from "../../../../../application/project-knowledge/project/init/InitializeProjectCommand.js";
-import { FsProjectInitializedEventStore } from "../../../../../infrastructure/project-knowledge/project/init/FsProjectInitializedEventStore.js";
-import { SqliteConnectionManager } from "../../../../../infrastructure/shared/persistence/SqliteConnectionManager.js";
-import { SqliteProjectInitializedProjector } from "../../../../../infrastructure/project-knowledge/project/init/SqliteProjectInitializedProjector.js";
-import { SqliteProjectUpdatedProjector } from "../../../../../infrastructure/project-knowledge/project/update/SqliteProjectUpdatedProjector.js";
-import { InProcessEventBus } from "../../../../../infrastructure/shared/messaging/InProcessEventBus.js";
-import { Renderer } from "../../../shared/rendering/Renderer.js";
-import { getBannerLines } from "../../../shared/components/AnimatedBanner.js";
-import { AgentFileProtocol } from "../../../../../infrastructure/project-knowledge/project/init/AgentFileProtocol.js";
 
 /**
- * Command handler
- * Called by Commander with parsed options
- *
- * Special case: Container is undefined for project init since .jumbo doesn't exist yet.
- * This command bootstraps the initial infrastructure.
+ * Command handler - receives container like all other controllers
  */
 export async function projectInit(
   options: {
@@ -71,90 +56,48 @@ export async function projectInit(
     purpose?: string;
     boundary?: string[];
   },
-  container?: ApplicationContainer
+  container: ApplicationContainer
 ) {
-  const jumboRoot = path.join(process.cwd(), ".jumbo");
-
   // Configure renderer for onboarding (always flashy/human-friendly)
   const renderer = Renderer.configure({ forceHuman: true });
 
   // Show welcome banner
   renderer.banner(getBannerLines());
 
-  // Check if already initialized
-  if (await fs.pathExists(jumboRoot)) {
-    renderer.error(
-      "Project already initialized. Use 'jumbo project update' to modify."
-    );
-    process.exit(1);
+  // Create command handler from container dependencies
+  const commandHandler = new InitializeProjectCommandHandler(
+    container.projectInitializedEventStore,
+    container.eventBus,
+    container.projectInitializedProjector,
+    container.agentFileProtocol
+  );
+
+  // Execute command
+  const command: InitializeProjectCommand = {
+    name: options.name,
+    tagline: options.tagline,
+    purpose: options.purpose,
+    boundaries: options.boundary,
+  };
+
+  const result = await commandHandler.execute(command, process.cwd());
+
+  // Success output (verbose for onboarding)
+  const data: Record<string, string> = {
+    projectId: result.projectId,
+    name: options.name,
+  };
+  if (options.tagline) {
+    data.tagline = options.tagline;
+  }
+  if (options.purpose) {
+    data.purpose = options.purpose;
   }
 
-  // Create .jumbo directory
-  await fs.ensureDir(jumboRoot);
-
-  // Project init creates its own infrastructure (container is undefined)
-  let dbConnectionManager: SqliteConnectionManager | undefined;
-
-  try {
-    // 1. Create infrastructure implementations (no container available yet)
-    const eventBus = new InProcessEventBus();
-    const eventStore = new FsProjectInitializedEventStore(jumboRoot);
-    dbConnectionManager = new SqliteConnectionManager(path.join(jumboRoot, "jumbo.db"));
-    const db = dbConnectionManager.getConnection();
-    const projectInitializedProjector = new SqliteProjectInitializedProjector(db);
-    const projectUpdatedProjector = new SqliteProjectUpdatedProjector(db);
-
-    // 2. Create application handlers (depend on abstractions)
-    const projectInitializedHandler = new ProjectInitializedEventHandler(projectInitializedProjector);
-    const projectUpdatedHandler = new ProjectUpdatedEventHandler(projectUpdatedProjector);
-    const agentFileProtocol = new AgentFileProtocol();
-    const commandHandler = new InitializeProjectCommandHandler(
-      eventStore,
-      eventBus,
-      projectInitializedProjector,
-      agentFileProtocol
-    );
-
-    // 3. Wire subscriptions (application handler subscribes to infrastructure event bus)
-    eventBus.subscribe("ProjectInitialized", projectInitializedHandler);
-    eventBus.subscribe("ProjectUpdated", projectUpdatedHandler);
-
-    // 4. Execute command
-    const command: InitializeProjectCommand = {
-      name: options.name,
-      tagline: options.tagline,
-      purpose: options.purpose,
-      boundaries: options.boundary,
-    };
-
-    const result = await commandHandler.execute(command, process.cwd());
-
-    // Success output (verbose for onboarding)
-    const data: Record<string, string> = {
-      projectId: result.projectId,
-      name: options.name,
-    };
-    if (options.tagline) {
-      data.tagline = options.tagline;
-    }
-    if (options.purpose) {
-      data.purpose = options.purpose;
-    }
-
-    renderer.success("Welcome to Jumbo! Project initialized successfully.", data);
-    renderer.info("✓ Claude Code SessionStart hook configured (.claude/settings.json)");
-    renderer.info("✓ Copilot instructions created (.github/copilot-instructions.md)");
-    renderer.info("ℹ Gemini users: See AGENTS.md for manual setup instructions");
-    renderer.info("");
-    renderer.info("Next steps: Start a session with 'jumbo session start --focus \"<your focus>\"'");
-  } catch (error) {
-    // Clean up on failure
-    await fs.remove(jumboRoot);
-    throw error;
-  } finally {
-    // Project init manages its own cleanup (special case)
-    if (dbConnectionManager) {
-      await dbConnectionManager.dispose();
-    }
-  }
+  renderer.success("Welcome to Jumbo! Project initialized successfully.", data);
+  renderer.info("✓ Claude Code SessionStart hook configured (.claude/settings.json)");
+  renderer.info("✓ Copilot instructions created (.github/copilot-instructions.md)");
+  renderer.info("ℹ Gemini users: See AGENTS.md for manual setup instructions");
+  renderer.info("");
+  renderer.info("Next steps: Start a session with 'jumbo session start --focus \"<your focus>\"'");
 }


### PR DESCRIPTION
  - Move infrastructure bootstrapping from project.init.ts to composition root
  - bootstrap.ts now creates .jumbo directory and manages all infrastructure state
  - SqliteConnectionManager auto-runs migrations for new databases
  - Add agentFileProtocol to ApplicationContainer
  - Extract migrations config to shared module (migrations.config.ts)
  - project.init.ts is now a simple controller receiving container like all others

  Architecture improvements:
  - Add doc comments to cli.ts explaining entry point responsibilities
  - Add doc comments to bootstrap.ts explaining composition root pattern
  - Add Replaceability Invariant to project knowledge

  Fixes presentation layer directly importing infrastructure implementations,
  which violated Clean Architecture dependency rules.
