### PR TITLE
Add configurable turn limit to QA mode on goal complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jumbo-cli",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jumbo-cli",
-      "version": "1.0.0-beta.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "better-sqlite3": "^12.4.1",
@@ -19,6 +19,7 @@
         "ink": "^3.2.0",
         "inquirer": "^8.2.5",
         "inversify": "^7.10.4",
+        "jsonc-parser": "^3.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "reflect-metadata": "^0.2.2",
@@ -4726,6 +4727,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ink": "^3.2.0",
     "inquirer": "^8.2.5",
     "inversify": "^7.10.4",
+    "jsonc-parser": "^3.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "reflect-metadata": "^0.2.2",
@@ -83,5 +84,5 @@
   },
   "engines": {
     "node": ">=18.18.0"
-  } 
+  }
 }

--- a/src/application/shared/settings/ISettingsReader.ts
+++ b/src/application/shared/settings/ISettingsReader.ts
@@ -1,0 +1,15 @@
+import { Settings } from "./Settings.js";
+
+/**
+ * Port interface for reading application settings.
+ * Used by application services to access configuration.
+ */
+export interface ISettingsReader {
+  /**
+   * Read settings from the configuration file.
+   * Creates file with defaults if it doesn't exist.
+   * @returns Promise<Settings> - The application settings
+   * @throws Error if file exists but contains invalid JSON
+   */
+  read(): Promise<Settings>;
+}

--- a/src/application/shared/settings/Settings.ts
+++ b/src/application/shared/settings/Settings.ts
@@ -1,0 +1,27 @@
+/**
+ * Settings type definitions for application-wide configuration.
+ * Settings are stored in .jumbo/settings.jsonc file.
+ */
+
+export interface QASettings {
+  /**
+   * Default turn limit for QA iterations on goal completion.
+   * When this limit is reached, the goal is automatically completed.
+   * Default: 3
+   */
+  defaultTurnLimit: number;
+
+  /**
+   * Optional: Warn user when approaching turn limit.
+   * If set, shows a warning at this turn number.
+   * Example: Setting to 2 warns at turn 2 of 3.
+   */
+  warnAtTurn?: number;
+}
+
+export interface Settings {
+  /**
+   * QA (Quality Assurance) settings for goal completion
+   */
+  qa: QASettings;
+}

--- a/src/application/work/goals/complete/CompleteGoalController.ts
+++ b/src/application/work/goals/complete/CompleteGoalController.ts
@@ -4,34 +4,48 @@ import { CompleteGoalPromptService } from "./CompleteGoalPromptService.js";
 import { CompleteGoalCommandHandler } from "./CompleteGoalCommandHandler.js";
 import { GetGoalContextQueryHandler } from "../get-context/GetGoalContextQueryHandler.js";
 import { IGoalCompleteReader } from "./IGoalCompleteReader.js";
+import { ReviewTurnTracker } from "./ReviewTurnTracker.js";
+import { IGoalReviewedEventWriter } from "./IGoalReviewedEventWriter.js";
+import { IGoalReviewedEventReader } from "./IGoalReviewedEventReader.js";
+import { IEventBus } from "../../../shared/messaging/IEventBus.js";
+import { Goal } from "../../../../domain/work/goals/Goal.js";
 
 /**
  * CompleteGoalController
  *
  * Controller for goal completion requests (similar to HTTP request controller).
- * Routes requests based on policy (commit flag) and returns structured responses.
+ * Routes requests based on policy (commit flag + turn limit) and returns structured responses.
  *
- * - QA Mode (commit=false): Returns criteria and QA prompt for verification
+ * - QA Mode (commit=false): Returns criteria and QA prompt for verification, records QA attempt
  * - Commit Mode (commit=true): Delegates to CompleteGoalCommandHandler and returns learnings prompt
+ * - Auto-Commit: When turn limit reached, automatically commits regardless of commit flag
  */
 export class CompleteGoalController {
   constructor(
     private readonly completeGoalCommandHandler: CompleteGoalCommandHandler,
     private readonly getGoalContextQueryHandler: GetGoalContextQueryHandler,
     private readonly goalReader: IGoalCompleteReader,
-    private readonly promptService: CompleteGoalPromptService
+    private readonly promptService: CompleteGoalPromptService,
+    private readonly turnTracker: ReviewTurnTracker,
+    private readonly reviewEventWriter: IGoalReviewedEventWriter,
+    private readonly goalEventReader: IGoalReviewedEventReader, // Use for full goal history
+    private readonly eventBus: IEventBus
   ) {}
 
   async handle(request: CompleteGoalRequest): Promise<CompleteGoalResponse> {
-    if (request.commit) {
-      return this.handleCommit(request.goalId);
+    // Check if we should auto-commit due to turn limit
+    const shouldAutoCommit = await this.turnTracker.shouldAutoCommit(request.goalId);
+    const effectiveCommit = request.commit || shouldAutoCommit;
+
+    if (effectiveCommit) {
+      return this.handleCommit(request.goalId, shouldAutoCommit);
     } else {
       return this.handleQA(request.goalId);
     }
   }
 
   /**
-   * Handle QA mode: Return criteria and QA prompt without changing goal state
+   * Handle QA mode: Return criteria and QA prompt, record review
    */
   private async handleQA(goalId: string): Promise<CompleteGoalResponse> {
     // Get current goal view
@@ -40,11 +54,27 @@ export class CompleteGoalController {
       throw new Error(`Goal not found: ${goalId}`);
     }
 
+    // Record review (before incrementing count for next turn)
+    const currentTurnCount = await this.turnTracker.getCurrentTurnCount(goalId);
+    const nextTurnNumber = currentTurnCount + 1;
+
+    // Rehydrate goal to record review
+    const history = await this.goalEventReader.readStream(goalId);
+    const goal = Goal.rehydrate(goalId, history as any);
+    const reviewEvent = goal.recordReview(nextTurnNumber);
+
+    // Persist and publish review event
+    await this.reviewEventWriter.append(reviewEvent);
+    await this.eventBus.publish(reviewEvent);
+
     // Get full goal context (criteria, components, invariants, etc.)
     const goalContext = await this.getGoalContextQueryHandler.execute(goalId);
 
-    // Generate QA prompt
-    const llmPrompt = this.promptService.generateQAPrompt(goalId);
+    // Calculate remaining turns (after recording this attempt)
+    const remainingTurns = await this.turnTracker.getRemainingTurns(goalId);
+
+    // Generate QA prompt with remaining turns
+    const llmPrompt = this.promptService.generateQAPrompt(goalId, remainingTurns);
 
     return {
       goalId,
@@ -52,13 +82,19 @@ export class CompleteGoalController {
       status: goalView.status,
       llmPrompt,
       criteria: goalContext,
+      remainingTurns,
     };
   }
 
   /**
    * Handle Commit mode: Delegate to CompleteGoalCommandHandler and return learnings prompt
+   * @param goalId - The goal ID to complete
+   * @param autoCommitted - True if this was auto-committed due to turn limit
    */
-  private async handleCommit(goalId: string): Promise<CompleteGoalResponse> {
+  private async handleCommit(
+    goalId: string,
+    autoCommitted: boolean = false
+  ): Promise<CompleteGoalResponse> {
     // Delegate to command handler (state change)
     await this.completeGoalCommandHandler.execute({ goalId });
 
@@ -91,6 +127,7 @@ export class CompleteGoalController {
       llmPrompt,
       // No criteria in commit mode (token optimization)
       nextGoal,
+      autoCommittedDueToTurnLimit: autoCommitted || undefined,
     };
   }
 }

--- a/src/application/work/goals/complete/CompleteGoalPromptService.ts
+++ b/src/application/work/goals/complete/CompleteGoalPromptService.ts
@@ -10,8 +10,9 @@ export class CompleteGoalPromptService {
    * This prompt instructs the LLM to check its work and fix any inconsistencies.
    *
    * @param goalId - The goal ID to include in the prompt
+   * @param remainingTurns - Number of remaining QA turns before auto-commit
    */
-  generateQAPrompt(goalId: string): string {
+  generateQAPrompt(goalId: string, remainingTurns: number): string {
     const lines = [
       "@LLM: Quality Assurance Check",
       "Review your work against the goal criteria below.",
@@ -20,8 +21,24 @@ export class CompleteGoalPromptService {
       "  2. If any criterion is not met, guideline not followed, or invariant not upheld, then fix the issues immediately",
       `  3. Only run 'jumbo goal complete --goal-id ${goalId} --commit' after ALL criteria, guidelines, and invariants are satisfied`,
       "",
-      "This is a verification loop - you MUST ensure all criteria are met before committing.",
+      `You have ${remainingTurns} QA turn(s) remaining.`,
     ];
+
+    if (remainingTurns === 0) {
+      lines.push(
+        "TURN LIMIT REACHED: The goal will be auto-completed on the next 'jumbo goal complete' command."
+      );
+    } else if (remainingTurns === 1) {
+      lines.push(
+        "WARNING: This is your last QA turn. The goal will be auto-completed if you run this command again."
+      );
+    }
+
+    lines.push("");
+    lines.push(
+      "This is a verification loop - you MUST ensure all criteria are met before committing."
+    );
+
     return lines.join("\n");
   }
 

--- a/src/application/work/goals/complete/CompleteGoalResponse.ts
+++ b/src/application/work/goals/complete/CompleteGoalResponse.ts
@@ -18,4 +18,6 @@ export interface CompleteGoalResponse {
     readonly objective: string;
     readonly status: string;
   };
+  readonly autoCommittedDueToTurnLimit?: boolean; // True if auto-committed due to turn limit
+  readonly remainingTurns?: number; // Number of remaining QA turns (only in QA mode)
 }

--- a/src/application/work/goals/complete/IGoalReviewedEventReader.ts
+++ b/src/application/work/goals/complete/IGoalReviewedEventReader.ts
@@ -1,0 +1,9 @@
+import { BaseEvent } from "../../../../domain/shared/BaseEvent.js";
+
+/**
+ * Port interface for reading goal reviewed events from event stream.
+ * Used by QATurnTracker to count reviews.
+ */
+export interface IGoalReviewedEventReader {
+  readStream(streamId: string): Promise<BaseEvent[]>;
+}

--- a/src/application/work/goals/complete/IGoalReviewedEventWriter.ts
+++ b/src/application/work/goals/complete/IGoalReviewedEventWriter.ts
@@ -1,0 +1,10 @@
+import { BaseEvent } from "../../../../domain/shared/BaseEvent.js";
+import { AppendResult } from "../../../shared/persistence/IEventStore.js";
+
+/**
+ * Port interface for writing GoalReviewedEvent to the event store.
+ * Used by CompleteGoalController to record completion reviews.
+ */
+export interface IGoalReviewedEventWriter {
+  append(event: BaseEvent & Record<string, any>): Promise<AppendResult>;
+}

--- a/src/application/work/goals/complete/ReviewTurnTracker.ts
+++ b/src/application/work/goals/complete/ReviewTurnTracker.ts
@@ -1,0 +1,98 @@
+import { IGoalReviewedEventReader } from "./IGoalReviewedEventReader.js";
+import { ISettingsReader } from "../../../shared/settings/ISettingsReader.js";
+import { GoalEventType } from "../../../../domain/work/goals/Constants.js";
+
+/**
+ * ReviewTurnTracker - Service for tracking review turn count and enforcing turn limits.
+ *
+ * Responsibilities:
+ * - Count reviews from event history
+ * - Read turn limit from settings
+ * - Determine when to auto-commit based on turn limit
+ * - Calculate remaining turns for user feedback
+ */
+export class ReviewTurnTracker {
+  constructor(
+    private readonly reviewEventReader: IGoalReviewedEventReader,
+    private readonly settingsReader: ISettingsReader
+  ) {}
+
+  /**
+   * Get the current turn count for a goal.
+   * Counts GoalReviewedEvent occurrences in the event stream.
+   *
+   * @param goalId - The goal ID to check
+   * @returns Promise<number> - Number of reviews so far
+   */
+  async getCurrentTurnCount(goalId: string): Promise<number> {
+    const events = await this.reviewEventReader.readStream(goalId);
+    return events.filter((e) => e.type === GoalEventType.REVIEWED).length;
+  }
+
+  /**
+   * Get the configured turn limit from settings.
+   *
+   * @returns Promise<number> - The turn limit from settings
+   */
+  async getTurnLimit(): Promise<number> {
+    const settings = await this.settingsReader.read();
+    return settings.qa.defaultTurnLimit;
+  }
+
+  /**
+   * Determine if the goal should be auto-committed based on turn count.
+   * Returns true if current turn count has reached or exceeded the limit.
+   *
+   * @param goalId - The goal ID to check
+   * @returns Promise<boolean> - True if should auto-commit
+   */
+  async shouldAutoCommit(goalId: string): Promise<boolean> {
+    const currentTurn = await this.getCurrentTurnCount(goalId);
+    const turnLimit = await this.getTurnLimit();
+    return currentTurn >= turnLimit;
+  }
+
+  /**
+   * Get the number of remaining review turns before auto-commit.
+   * Returns 0 if limit has been reached or exceeded.
+   *
+   * @param goalId - The goal ID to check
+   * @returns Promise<number> - Number of remaining turns
+   */
+  async getRemainingTurns(goalId: string): Promise<number> {
+    const currentTurn = await this.getCurrentTurnCount(goalId);
+    const turnLimit = await this.getTurnLimit();
+    const remaining = turnLimit - currentTurn;
+    return Math.max(0, remaining);
+  }
+
+  /**
+   * Get the warn-at-turn threshold from settings.
+   * Returns undefined if not configured.
+   *
+   * @returns Promise<number | undefined> - The warn threshold or undefined
+   */
+  async getWarnAtTurn(): Promise<number | undefined> {
+    const settings = await this.settingsReader.read();
+    return settings.qa.warnAtTurn;
+  }
+
+  /**
+   * Determine if a warning should be shown based on current turn count.
+   *
+   * @param goalId - The goal ID to check
+   * @returns Promise<boolean> - True if warning should be shown
+   */
+  async shouldShowWarning(goalId: string): Promise<boolean> {
+    const warnAtTurn = await this.getWarnAtTurn();
+    if (warnAtTurn === undefined) {
+      return false;
+    }
+
+    const currentTurn = await this.getCurrentTurnCount(goalId);
+    const turnLimit = await this.getTurnLimit();
+
+    // Show warning if current turn equals warn threshold and we haven't reached limit yet
+    return currentTurn === warnAtTurn && currentTurn < turnLimit;
+  }
+}

--- a/src/domain/work/goals/Constants.ts
+++ b/src/domain/work/goals/Constants.ts
@@ -14,7 +14,8 @@ export const GoalEventType = {
   RESUMED: 'GoalResumedEvent',
   COMPLETED: 'GoalCompletedEvent',
   RESET: 'GoalResetEvent',
-  REMOVED: 'GoalRemovedEvent'
+  REMOVED: 'GoalRemovedEvent',
+  REVIEWED: 'GoalReviewedEvent'
 } as const;
 
 export type GoalEventTypeValue = typeof GoalEventType[keyof typeof GoalEventType];

--- a/src/domain/work/goals/EventIndex.ts
+++ b/src/domain/work/goals/EventIndex.ts
@@ -1,6 +1,7 @@
 export * from "./add/GoalAddedEvent.js";
 export * from "./block/GoalBlockedEvent.js";
 export * from "./complete/GoalCompletedEvent.js";
+export * from "./complete/GoalReviewedEvent.js";
 export * from "./pause/GoalPausedEvent.js";
 export * from "./remove/GoalRemovedEvent.js";
 export * from "./reset/GoalResetEvent.js";
@@ -13,6 +14,7 @@ import { GoalAddedEvent} from "./add/GoalAddedEvent.js";
 import { GoalBlockedEvent} from "./block/GoalBlockedEvent.js";
 import { GoalCompletedEvent} from "./complete/GoalCompletedEvent.js";
 import { GoalPausedEvent} from "./pause/GoalPausedEvent.js";
+import { GoalReviewedEvent} from "./complete/GoalReviewedEvent.js";
 import { GoalRemovedEvent} from "./remove/GoalRemovedEvent.js";
 import { GoalResetEvent} from "./reset/GoalResetEvent.js";
 import { GoalResumedEvent} from "./resume/GoalResumedEvent.js";
@@ -26,6 +28,7 @@ export type GoalEvent =
     GoalBlockedEvent |
     GoalCompletedEvent |
     GoalPausedEvent |
+    GoalReviewedEvent |
     GoalRemovedEvent |
     GoalResetEvent |
     GoalResumedEvent |

--- a/src/domain/work/goals/complete/GoalReviewedEvent.ts
+++ b/src/domain/work/goals/complete/GoalReviewedEvent.ts
@@ -1,0 +1,14 @@
+import { BaseEvent } from "../../../shared/BaseEvent.js";
+
+/**
+ * Emitted when a goal completion is reviewed during the QA process.
+ * Used to track the number of review iterations and enforce turn limits.
+ * Does not change goal status - purely for tracking purposes.
+ */
+export interface GoalReviewedEvent extends BaseEvent {
+  readonly type: "GoalReviewedEvent";
+  readonly payload: {
+    readonly reviewedAt: string;  // ISO 8601 timestamp
+    readonly turnNumber: number;    // The turn number for this review
+  };
+}

--- a/src/infrastructure/shared/settings/DefaultSettings.ts
+++ b/src/infrastructure/shared/settings/DefaultSettings.ts
@@ -1,0 +1,12 @@
+import { Settings } from "../../../application/shared/settings/Settings.js";
+
+/**
+ * Default settings used when no settings file exists
+ * or when creating a new settings file.
+ */
+export const DEFAULT_SETTINGS: Settings = {
+  qa: {
+    defaultTurnLimit: 3,
+    warnAtTurn: 2,
+  },
+};

--- a/src/infrastructure/shared/settings/FsSettingsInitializer.ts
+++ b/src/infrastructure/shared/settings/FsSettingsInitializer.ts
@@ -1,0 +1,39 @@
+import fs from "fs-extra";
+import path from "path";
+
+/**
+ * FsSettingsInitializer - Creates settings file with defaults if it doesn't exist.
+ *
+ * Called during bootstrap to ensure settings infrastructure is ready.
+ * Only creates the file if missing - doesn't overwrite existing settings.
+ */
+export class FsSettingsInitializer {
+  private readonly settingsFilePath: string;
+
+  constructor(rootDir: string) {
+    this.settingsFilePath = path.join(rootDir, "settings.jsonc");
+  }
+
+  async ensureSettingsFileExists(): Promise<void> {
+    // Only create if it doesn't exist
+    if (await fs.pathExists(this.settingsFilePath)) {
+      return;
+    }
+
+    const content = `{
+  // Quality Assurance settings for goal completion
+  "qa": {
+    // Default turn limit for QA iterations on goal completion
+    // When this limit is reached, the goal is automatically completed
+    "defaultTurnLimit": 3,
+
+    // Optional: Warn user when approaching turn limit
+    // Shows a warning at this turn number
+    "warnAtTurn": 2
+  }
+}
+`;
+
+    await fs.writeFile(this.settingsFilePath, content, "utf-8");
+  }
+}

--- a/src/infrastructure/shared/settings/FsSettingsReader.ts
+++ b/src/infrastructure/shared/settings/FsSettingsReader.ts
@@ -1,0 +1,101 @@
+import fs from "fs-extra";
+import path from "path";
+import * as jsonc from "jsonc-parser";
+import { ISettingsReader } from "../../../application/shared/settings/ISettingsReader.js";
+import { Settings } from "../../../application/shared/settings/Settings.js";
+import { DEFAULT_SETTINGS } from "./DefaultSettings.js";
+
+/**
+ * JsoncSettingsReader - File system implementation for reading settings.
+ *
+ * Reads settings from .jumbo/settings.jsonc file.
+ * Creates the file with defaults if it doesn't exist.
+ * Supports JSONC format (JSON with comments).
+ */
+export class FsSettingsReader implements ISettingsReader {
+  private readonly settingsFilePath: string;
+
+  constructor(rootDir: string) {
+    this.settingsFilePath = path.join(rootDir, "settings.jsonc");
+  }
+
+  async read(): Promise<Settings> {
+    // Check if settings file exists
+    if (!(await fs.pathExists(this.settingsFilePath))) {
+      // Create file with defaults
+      await this.createDefaultSettingsFile();
+      return DEFAULT_SETTINGS;
+    }
+
+    // Read and parse existing file
+    try {
+      const content = await fs.readFile(this.settingsFilePath, "utf-8");
+      const errors: jsonc.ParseError[] = [];
+      const settings = jsonc.parse(content, errors, {
+        allowTrailingComma: true,
+      }) as Settings;
+
+      if (errors.length > 0) {
+        throw new Error(
+          `Invalid JSON in settings file: ${this.formatParseErrors(errors)}`
+        );
+      }
+
+      // Merge with defaults to handle missing fields
+      return this.mergeWithDefaults(settings);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(
+          `Failed to read settings file at ${this.settingsFilePath}: ${error.message}`
+        );
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Create settings file with default values and helpful comments
+   */
+  private async createDefaultSettingsFile(): Promise<void> {
+    const content = `{
+  // Quality Assurance settings for goal completion
+  "qa": {
+    // Default turn limit for QA iterations on goal completion
+    // When this limit is reached, the goal is automatically completed
+    "defaultTurnLimit": 3,
+
+    // Optional: Warn user when approaching turn limit
+    // Shows a warning at this turn number
+    "warnAtTurn": 2
+  }
+}
+`;
+
+    await fs.writeFile(this.settingsFilePath, content, "utf-8");
+  }
+
+  /**
+   * Merge parsed settings with defaults to handle missing fields
+   */
+  private mergeWithDefaults(settings: Partial<Settings>): Settings {
+    return {
+      qa: {
+        defaultTurnLimit:
+          settings.qa?.defaultTurnLimit ?? DEFAULT_SETTINGS.qa.defaultTurnLimit,
+        warnAtTurn: settings.qa?.warnAtTurn ?? DEFAULT_SETTINGS.qa.warnAtTurn,
+      },
+    };
+  }
+
+  /**
+   * Format parse errors into a readable message
+   */
+  private formatParseErrors(errors: jsonc.ParseError[]): string {
+    return errors
+      .map(
+        (err) =>
+          `Error at offset ${err.offset}: ${jsonc.printParseErrorCode(err.error)}`
+      )
+      .join(", ");
+  }
+}

--- a/src/infrastructure/work/goals/complete/FsGoalReviewedEventStore.ts
+++ b/src/infrastructure/work/goals/complete/FsGoalReviewedEventStore.ts
@@ -1,0 +1,21 @@
+/**
+ * FsGoalReviewedEventStore - File system event store for GoalReviewedEvent.
+ *
+ * Implements IGoalReviewedEventWriter and IGoalReviewedEventReader for
+ * persisting and reading goal reviewed events.
+ * Extends the base FsEventStore implementation.
+ * Reuses the goal's event stream storage.
+ */
+
+import { FsEventStore } from "../../../shared/persistence/FsEventStore.js";
+import { IGoalReviewedEventWriter } from "../../../../application/work/goals/complete/IGoalReviewedEventWriter.js";
+import { IGoalReviewedEventReader } from "../../../../application/work/goals/complete/IGoalReviewedEventReader.js";
+
+export class FsGoalReviewedEventStore
+  extends FsEventStore
+  implements IGoalReviewedEventWriter, IGoalReviewedEventReader
+{
+  constructor(rootDir: string) {
+    super(rootDir);
+  }
+}

--- a/src/presentation/cli/shared/banner/BannerOrchestrator.ts
+++ b/src/presentation/cli/shared/banner/BannerOrchestrator.ts
@@ -72,7 +72,7 @@ export async function showBanner(version: string): Promise<void> {
 
   let container: ApplicationContainer | null = null;
   if (projectExists) {
-    container = bootstrap(jumboRoot);
+    container = await bootstrap(jumboRoot);
   }
 
   const displayContext = await gatherDisplayContext(container);

--- a/src/presentation/cli/shared/routing/CommandRouter.ts
+++ b/src/presentation/cli/shared/routing/CommandRouter.ts
@@ -128,7 +128,7 @@ async function executeCommand(
   let container: ApplicationContainer | undefined;
 
   if (!isSubcommandHelp) {
-    container = bootstrap(jumboRoot);
+    container = await bootstrap(jumboRoot);
   }
 
   try {

--- a/src/presentation/cli/work/goals/complete/goal.complete.ts
+++ b/src/presentation/cli/work/goals/complete/goal.complete.ts
@@ -69,6 +69,12 @@ export async function goalComplete(
 
     // 4. Render response
 
+    // Show auto-commit warning if applicable
+    if (response.autoCommittedDueToTurnLimit) {
+      renderer.info("⚠️  Turn limit reached - Goal auto-completed");
+      renderer.info("The QA turn limit has been reached. The goal has been automatically completed.\n");
+    }
+
     // Render criteria if present (QA mode)
     if (response.criteria) {
       const formatter = new GoalContextFormatter();
@@ -79,6 +85,18 @@ export async function goalComplete(
     // Render LLM prompt
     renderer.info("---\n");
     renderer.info(response.llmPrompt + "\n");
+
+    // Show remaining turns if in QA mode
+    if (response.remainingTurns !== undefined) {
+      if (response.remainingTurns === 0) {
+        renderer.info(`⚠️  QA turns remaining: ${response.remainingTurns} (limit will be reached on next attempt)`);
+      } else if (response.remainingTurns === 1) {
+        renderer.info(`⚠️  QA turns remaining: ${response.remainingTurns} (last turn before auto-complete)`);
+      } else {
+        renderer.info(`QA turns remaining: ${response.remainingTurns}`);
+      }
+      renderer.info("");
+    }
 
     // Render goal status
     const statusMessage = response.criteria ? "Goal verification ready" : "Goal completed";

--- a/tests/integration/goal-lifecycle-tracking.integration.test.ts
+++ b/tests/integration/goal-lifecycle-tracking.integration.test.ts
@@ -44,7 +44,7 @@ describe("Integration: Goal Lifecycle Tracking", () => {
   });
 
   it("should track goal started events in session summary", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const sessionId = "session_lifecycle_test_1";
     const goalId = "goal_started_test_1";
@@ -110,7 +110,7 @@ describe("Integration: Goal Lifecycle Tracking", () => {
   });
 
   it("should track goal paused events with reason and note", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const sessionId = "session_lifecycle_test_2";
     const goalId = "goal_paused_test_2";
@@ -192,7 +192,7 @@ describe("Integration: Goal Lifecycle Tracking", () => {
   });
 
   it("should track goal resumed events", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const sessionId = "session_lifecycle_test_3";
     const goalId = "goal_resumed_test_3";
@@ -282,7 +282,7 @@ describe("Integration: Goal Lifecycle Tracking", () => {
   });
 
   it("should preserve goal lifecycle data when archiving session", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const session1Id = "session_archive_test_1";
     const session2Id = "session_archive_test_2";
@@ -384,7 +384,7 @@ describe("Integration: Goal Lifecycle Tracking", () => {
   });
 
   it("should include resume prompt in formatter output when goals are paused", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const sessionId = "session_formatter_test";
     const goalId = "goal_formatter_test";
@@ -457,7 +457,7 @@ describe("Integration: Goal Lifecycle Tracking", () => {
   });
 
   it("should track multiple goal lifecycle events in one session", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const sessionId = "session_multiple_test";
     const goal1Id = "goal_multiple_1";

--- a/tests/integration/infrastructure-wiring.test.ts
+++ b/tests/integration/infrastructure-wiring.test.ts
@@ -12,7 +12,7 @@ describe("Infrastructure Wiring Integration", () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(process.cwd(), "test-integration-"));
-    container = bootstrap(tmpDir);
+    container = await bootstrap(tmpDir);
   });
 
   afterEach(async () => {

--- a/tests/integration/pause-resume-lifecycle.test.ts
+++ b/tests/integration/pause-resume-lifecycle.test.ts
@@ -27,7 +27,7 @@ describe("Pause-Resume Lifecycle Integration", () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(process.cwd(), "test-pause-resume-"));
-    container = bootstrap(tmpDir);
+    container = await bootstrap(tmpDir);
   });
 
   afterEach(async () => {

--- a/tests/integration/session-context-rendering.integration.test.ts
+++ b/tests/integration/session-context-rendering.integration.test.ts
@@ -49,7 +49,7 @@ describe("Integration: Session Context Rendering", () => {
     // ============================================================
     // STEP 1: Start first session (publish SessionStarted event)
     // ============================================================
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const sessionId = "session_test_123";
     const goalId = "goal_test_456";
@@ -175,7 +175,7 @@ describe("Integration: Session Context Rendering", () => {
     // ============================================================
     // Fresh start - no previous sessions
     // ============================================================
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     const getLatestSessionSummary = new GetLatestSessionSummaryQueryHandler(
       container.sessionSummaryProjectionStore

--- a/tests/presentation/cli/composition/bootstrap.test.ts
+++ b/tests/presentation/cli/composition/bootstrap.test.ts
@@ -35,8 +35,8 @@ describe("bootstrap", () => {
     await fs.remove(testRoot);
   });
 
-  it("should create a complete application container", () => {
-    container = bootstrap(testRoot);
+  it("should create a complete application container", async () => {
+    container = await bootstrap(testRoot);
 
     // Verify core infrastructure
     expect(container.eventBus).toBeDefined();
@@ -158,8 +158,8 @@ describe("bootstrap", () => {
     expect(container.relationRemovedProjector).toBeDefined();
   });
 
-  it("should NOT expose dbConnectionManager (lifecycle managed by LocalInfrastructureModule)", () => {
-    container = bootstrap(testRoot);
+  it("should NOT expose dbConnectionManager (lifecycle managed by LocalInfrastructureModule)", async () => {
+    container = await bootstrap(testRoot);
 
     // Verify dbConnectionManager is NOT part of the container
     // This ensures presentation layer cannot call dispose()
@@ -167,7 +167,7 @@ describe("bootstrap", () => {
   });
 
   it("should register all projection handlers with event bus", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     // Create a test session event
     const sessionStartedEvent = {
@@ -196,7 +196,7 @@ describe("bootstrap", () => {
   });
 
   it("should handle goal events through registered handlers", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     // Create a test goal event
     const goalAddedEvent = {
@@ -230,8 +230,8 @@ describe("bootstrap", () => {
     expect(goal?.status).toBe("to-do");
   });
 
-  it("should create database connection with proper tables", () => {
-    container = bootstrap(testRoot);
+  it("should create database connection with proper tables", async () => {
+    container = await bootstrap(testRoot);
 
     // Verify database was created
     const dbPath = path.join(testRoot, "jumbo.db");
@@ -248,7 +248,7 @@ describe("bootstrap", () => {
   });
 
   it("should support cross-aggregate projections", async () => {
-    container = bootstrap(testRoot);
+    container = await bootstrap(testRoot);
 
     // Start a session
     const sessionEvent = {


### PR DESCRIPTION
Implements automatic completion after a configurable number of QA review turns. Goals now auto-commit when the turn limit is reached, with warnings shown to users as they approach the limit. Adds settings infrastructure to read configuration from .jumbo/settings.jsonc and tracks review attempts via GoalReviewedEvent.
