### PR TITLE
refactor: use event type constants instead of hardcoded strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "search.useIgnoreFiles": false
+    "search.useIgnoreFiles": false,
+    "search.defaultViewMode": "tree"
 }

--- a/src/domain/solution/decisions/add/DecisionAddedEvent.ts
+++ b/src/domain/solution/decisions/add/DecisionAddedEvent.ts
@@ -6,9 +6,10 @@
  */
 
 import { BaseEvent } from "../../../shared/BaseEvent.js";
+import { DecisionEventType } from "../Constants.js";
 
 export interface DecisionAddedEvent extends BaseEvent {
-  readonly type: "DecisionAddedEvent";
+  readonly type: typeof DecisionEventType.ADDED;
   readonly payload: {
     readonly title: string;
     readonly context: string;

--- a/src/domain/solution/decisions/reverse/DecisionReversedEvent.ts
+++ b/src/domain/solution/decisions/reverse/DecisionReversedEvent.ts
@@ -5,11 +5,11 @@
  * Marks the decision as no longer applicable with a reason for reversal.
  */
 
-import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { ISO8601 } from "../../../shared/BaseEvent.js";
+import { BaseEvent, ISO8601 } from "../../../shared/BaseEvent.js";
+import { DecisionEventType } from "../Constants.js";
 
 export interface DecisionReversedEvent extends BaseEvent {
-  readonly type: "DecisionReversedEvent";
+  readonly type: typeof DecisionEventType.REVERSED;
   readonly payload: {
     readonly reason: string;
     readonly reversedAt: ISO8601;

--- a/src/domain/solution/decisions/supersede/DecisionSupersededEvent.ts
+++ b/src/domain/solution/decisions/supersede/DecisionSupersededEvent.ts
@@ -6,9 +6,10 @@
  */
 
 import { BaseEvent, UUID } from "../../../shared/BaseEvent.js";
+import { DecisionEventType } from "../Constants.js";
 
 export interface DecisionSupersededEvent extends BaseEvent {
-  readonly type: "DecisionSupersededEvent";
+  readonly type: typeof DecisionEventType.SUPERSEDED;
   readonly payload: {
     readonly supersededBy: UUID;
   };

--- a/src/domain/solution/decisions/update/DecisionUpdatedEvent.ts
+++ b/src/domain/solution/decisions/update/DecisionUpdatedEvent.ts
@@ -5,9 +5,10 @@
  */
 
 import { BaseEvent } from "../../../shared/BaseEvent.js";
+import { DecisionEventType } from "../Constants.js";
 
 export interface DecisionUpdatedEvent extends BaseEvent {
-  readonly type: "DecisionUpdatedEvent";
+  readonly type: typeof DecisionEventType.UPDATED;
   readonly payload: {
     readonly title?: string;
     readonly context?: string;

--- a/src/domain/work/goals/add/GoalAddedEvent.ts
+++ b/src/domain/work/goals/add/GoalAddedEvent.ts
@@ -1,5 +1,5 @@
 import { BaseEvent, UUID } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 import {
   EmbeddedInvariant,
   EmbeddedGuideline,
@@ -14,7 +14,7 @@ import {
  * Goal starts in 'to-do' status.
  */
 export interface GoalAddedEvent extends BaseEvent {
-  readonly type: "GoalAddedEvent";
+  readonly type: typeof GoalEventType.ADDED;
   readonly payload: {
     readonly objective: string;
     readonly successCriteria: string[];

--- a/src/domain/work/goals/block/GoalBlockedEvent.ts
+++ b/src/domain/work/goals/block/GoalBlockedEvent.ts
@@ -1,5 +1,5 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 
 /**
  * Emitted when a goal is blocked.
@@ -7,7 +7,7 @@ import { GoalStatusType } from "../Constants.js";
  * Captures the reason for blocking in the note field.
  */
 export interface GoalBlockedEvent extends BaseEvent {
-  readonly type: "GoalBlockedEvent";
+  readonly type: typeof GoalEventType.BLOCKED;
   readonly payload: {
     readonly status: GoalStatusType;  // Will be 'blocked'
     readonly note: string;             // Reason for blocking

--- a/src/domain/work/goals/complete/GoalCompletedEvent.ts
+++ b/src/domain/work/goals/complete/GoalCompletedEvent.ts
@@ -1,12 +1,12 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 
 /**
  * Emitted when a goal's work is completed and all success criteria are met.
  * Transitions goal status from 'doing' or 'blocked' to 'completed'.
  */
 export interface GoalCompletedEvent extends BaseEvent {
-  readonly type: "GoalCompletedEvent";
+  readonly type: typeof GoalEventType.COMPLETED;
   readonly payload: {
     readonly status: GoalStatusType;  // Will be 'completed'
   };

--- a/src/domain/work/goals/complete/GoalReviewedEvent.ts
+++ b/src/domain/work/goals/complete/GoalReviewedEvent.ts
@@ -1,4 +1,5 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
+import { GoalEventType } from "../Constants.js";
 
 /**
  * Emitted when a goal completion is reviewed during the QA process.
@@ -6,7 +7,7 @@ import { BaseEvent } from "../../../shared/BaseEvent.js";
  * Does not change goal status - purely for tracking purposes.
  */
 export interface GoalReviewedEvent extends BaseEvent {
-  readonly type: "GoalReviewedEvent";
+  readonly type: typeof GoalEventType.REVIEWED;
   readonly payload: {
     readonly reviewedAt: string;  // ISO 8601 timestamp
     readonly turnNumber: number;    // The turn number for this review

--- a/src/domain/work/goals/pause/GoalPausedEvent.ts
+++ b/src/domain/work/goals/pause/GoalPausedEvent.ts
@@ -1,5 +1,5 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 import { GoalPausedReasonsType } from "../GoalPausedReasons.js";
 
 /**
@@ -8,7 +8,7 @@ import { GoalPausedReasonsType } from "../GoalPausedReasons.js";
  * Captures the reason and optional note for pausing.
  */
 export interface GoalPausedEvent extends BaseEvent {
-  readonly type: "GoalPausedEvent";
+  readonly type: typeof GoalEventType.PAUSED;
   readonly payload: {
     readonly status: GoalStatusType;     // Will be 'paused'
     readonly reason: GoalPausedReasonsType;  // Reason for pausing

--- a/src/domain/work/goals/remove/GoalRemovedEvent.ts
+++ b/src/domain/work/goals/remove/GoalRemovedEvent.ts
@@ -1,4 +1,5 @@
 import { BaseEvent, ISO8601 } from "../../../shared/BaseEvent.js";
+import { GoalEventType } from "../Constants.js";
 
 /**
  * Emitted when a goal is removed from the system.
@@ -6,7 +7,7 @@ import { BaseEvent, ISO8601 } from "../../../shared/BaseEvent.js";
  * The goal's history remains in the event store but it will not appear in active queries.
  */
 export interface GoalRemovedEvent extends BaseEvent {
-  readonly type: "GoalRemovedEvent";
+  readonly type: typeof GoalEventType.REMOVED;
   readonly payload: {
     readonly removedAt: ISO8601;
   };

--- a/src/domain/work/goals/reset/GoalResetEvent.ts
+++ b/src/domain/work/goals/reset/GoalResetEvent.ts
@@ -1,12 +1,12 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 
 /**
  * Emitted when a goal is reset to 'to-do' status.
  * Can transition from any status (doing, blocked, completed) back to 'to-do'.
  */
 export interface GoalResetEvent extends BaseEvent {
-  readonly type: "GoalResetEvent";
+  readonly type: typeof GoalEventType.RESET;
   readonly payload: {
     readonly status: GoalStatusType;  // Will be 'to-do'
   };

--- a/src/domain/work/goals/resume/GoalResumedEvent.ts
+++ b/src/domain/work/goals/resume/GoalResumedEvent.ts
@@ -1,5 +1,5 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 
 /**
  * Emitted when a goal is resumed from paused status.
@@ -7,7 +7,7 @@ import { GoalStatusType } from "../Constants.js";
  * Captures optional note about resumption.
  */
 export interface GoalResumedEvent extends BaseEvent {
-  readonly type: "GoalResumedEvent";
+  readonly type: typeof GoalEventType.RESUMED;
   readonly payload: {
     readonly status: GoalStatusType;     // Will be 'doing'
     readonly note?: string;              // Optional note about resumption

--- a/src/domain/work/goals/start/GoalStartedEvent.ts
+++ b/src/domain/work/goals/start/GoalStartedEvent.ts
@@ -1,12 +1,12 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
-import { GoalStatusType } from "../Constants.js";
+import { GoalEventType, GoalStatusType } from "../Constants.js";
 
 /**
  * Emitted when a defined goal is started (work begins).
  * Transitions goal status from "to-do" to "doing".
  */
 export interface GoalStartedEvent extends BaseEvent {
-  readonly type: "GoalStartedEvent";
+  readonly type: typeof GoalEventType.STARTED;
   readonly payload: {
     readonly status: GoalStatusType; // "doing"
   };

--- a/src/domain/work/goals/unblock/GoalUnblockedEvent.ts
+++ b/src/domain/work/goals/unblock/GoalUnblockedEvent.ts
@@ -1,11 +1,12 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
+import { GoalEventType } from "../Constants.js";
 
 /**
  * Emitted when a blocked goal is unblocked and resumes.
  * Transitions goal status from 'blocked' back to 'doing'.
  */
 export interface GoalUnblockedEvent extends BaseEvent {
-  readonly type: 'GoalUnblockedEvent';
+  readonly type: typeof GoalEventType.UNBLOCKED;
   readonly payload: {
     readonly status: 'doing';  // Resume to doing
     readonly note?: string;    // Optional resolution note

--- a/src/domain/work/goals/update/GoalUpdatedEvent.ts
+++ b/src/domain/work/goals/update/GoalUpdatedEvent.ts
@@ -1,4 +1,5 @@
 import { BaseEvent, UUID } from "../../../shared/BaseEvent.js";
+import { GoalEventType } from "../Constants.js";
 import {
   EmbeddedInvariant,
   EmbeddedGuideline,
@@ -12,7 +13,7 @@ import {
  * Only fields provided in payload are updated; omitted fields remain unchanged.
  */
 export interface GoalUpdatedEvent extends BaseEvent {
-  readonly type: "GoalUpdatedEvent";
+  readonly type: typeof GoalEventType.UPDATED;
   readonly payload: {
     readonly objective?: string;
     readonly successCriteria?: string[];

--- a/src/domain/work/sessions/end/SessionEndedEvent.ts
+++ b/src/domain/work/sessions/end/SessionEndedEvent.ts
@@ -1,11 +1,12 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
+import { SessionEventType } from "../Constants.js";
 
 /**
  * Emitted when a session is ended.
  * Captures the final focus/summary of work accomplished.
  */
 export interface SessionEndedEvent extends BaseEvent {
-  readonly type: "SessionEndedEvent";
+  readonly type: typeof SessionEventType.ENDED;
   readonly payload: {
     readonly focus: string;
     readonly summary: string | null;

--- a/src/domain/work/sessions/start/SessionStartedEvent.ts
+++ b/src/domain/work/sessions/start/SessionStartedEvent.ts
@@ -1,4 +1,5 @@
 import { BaseEvent } from "../../../shared/BaseEvent.js";
+import { SessionEventType } from "../Constants.js";
 
 /**
  * Emitted when a developer starts a new working session.
@@ -6,6 +7,6 @@ import { BaseEvent } from "../../../shared/BaseEvent.js";
  * Focus is not captured at session start - it's captured at session end as a summary.
  */
 export interface SessionStartedEvent extends BaseEvent {
-  readonly type: "SessionStartedEvent";
+  readonly type: typeof SessionEventType.STARTED;
   readonly payload: Record<string, never>; // No payload - session start has no parameters
 }

--- a/tests/application/solution/architecture/view/ViewArchitectureCommandHandler.test.ts
+++ b/tests/application/solution/architecture/view/ViewArchitectureCommandHandler.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
-import { ViewArchitectureCommandHandler } from "../../../../../../src/application/solution/architecture/view/ViewArchitectureCommandHandler.js";
-import { IArchitectureViewer } from "../../../../../../src/application/solution/architecture/view/IArchitectureViewer.js";
-import { ArchitectureView } from "../../../../../../src/application/solution/architecture/ArchitectureView.js";
+import { ViewArchitectureCommandHandler } from "../../../../../src/application/solution/architecture/view/ViewArchitectureCommandHandler.js";
+import { IArchitectureViewer } from "../../../../../src/application/solution/architecture/view/IArchitectureViewer.js";
+import { ArchitectureView } from "../../../../../src/application/solution/architecture/ArchitectureView.js";
 
 describe("ViewArchitectureCommandHandler", () => {
   let commandHandler: ViewArchitectureCommandHandler;


### PR DESCRIPTION
   - Decision events now use DecisionEventType constants
   - Goal events now use GoalEventType constants
   - Session events now use SessionEventType constants
   - Fix import path in ViewArchitectureCommandHandler.test.ts
