### PR TITLE
chore: Remove findAll fallback from SqliteGoalContextAssembler

### DIFF
--- a/src/infrastructure/context/SqliteGoalContextAssembler.ts
+++ b/src/infrastructure/context/SqliteGoalContextAssembler.ts
@@ -24,10 +24,8 @@ import { EntityType } from "../../domain/relations/Constants.js";
  * 1. Query active relations from goal
  * 2. Group related entity IDs by type
  * 3. Batch fetch entities (one query per type)
- *    - If no relations exist, fetches ALL entities to provide complete project context
- *    - If relations exist, fetches only related entities
+ *    - Fetches only related entities
  * 4. Merge entity data with relation metadata into RelatedContext<T>
- *    - Default relation metadata used when no explicit relations exist
  * 5. Return complete ContextualGoalView (goal + context)
  *
  * Performance: ~7 queries worst case (goal + relations + 6 entity types)
@@ -53,7 +51,6 @@ export class SqliteGoalContextAssembler implements IGoalContextAssembler {
     // 2. Query relations where fromEntity = goal and status = active
     const allRelations = await this.relationReader.findByFromEntity(EntityType.GOAL, goalId);
     const relations = allRelations.filter(r => r.status === 'active');
-    const hasNoRelations = relations.length === 0;
 
     // 3. Group related entity IDs by type
     const componentIds = relations
@@ -79,7 +76,6 @@ export class SqliteGoalContextAssembler implements IGoalContextAssembler {
     const hasArchitectureRelation = relations.some(r => r.toEntityType === EntityType.ARCHITECTURE);
 
     // 4. Batch fetch entities (parallel queries)
-    // If no relations exist, fetch all entities to provide complete project context
     const [
       componentViews,
       dependencyViews,
@@ -88,12 +84,12 @@ export class SqliteGoalContextAssembler implements IGoalContextAssembler {
       guidelineViews,
       architectureView
     ] = await Promise.all([
-      hasNoRelations ? this.componentReader.findAll() : this.componentReader.findByIds(componentIds),
-      hasNoRelations ? this.dependencyReader.findAll() : this.dependencyReader.findByIds(dependencyIds),
-      hasNoRelations ? this.decisionReader.findAll("active") : this.decisionReader.findByIds(decisionIds),
-      hasNoRelations ? this.invariantReader.findAll() : this.invariantReader.findByIds(invariantIds),
-      hasNoRelations ? this.guidelineReader.findAll() : this.guidelineReader.findByIds(guidelineIds),
-      hasNoRelations || hasArchitectureRelation ? this.architectureReader.find() : Promise.resolve(null)
+      this.componentReader.findByIds(componentIds),
+      this.dependencyReader.findByIds(dependencyIds),
+      this.decisionReader.findByIds(decisionIds),
+      this.invariantReader.findByIds(invariantIds),
+      this.guidelineReader.findByIds(guidelineIds),
+      hasArchitectureRelation ? this.architectureReader.find() : Promise.resolve(null)
     ]);
 
     // 5. Merge entity data with relation metadata into RelatedContext<T>
@@ -103,23 +99,23 @@ export class SqliteGoalContextAssembler implements IGoalContextAssembler {
     );
 
     const components = this.toRelatedContexts(
-      componentViews, EntityType.COMPONENT, v => v.componentId, relationMap, hasNoRelations
+      componentViews, EntityType.COMPONENT, v => v.componentId, relationMap
     );
 
     const dependencies = this.toRelatedContexts(
-      dependencyViews, EntityType.DEPENDENCY, v => v.dependencyId, relationMap, hasNoRelations
+      dependencyViews, EntityType.DEPENDENCY, v => v.dependencyId, relationMap
     );
 
     const decisions = this.toRelatedContexts(
-      decisionViews, EntityType.DECISION, v => v.decisionId, relationMap, hasNoRelations
+      decisionViews, EntityType.DECISION, v => v.decisionId, relationMap
     );
 
     const invariants = this.toRelatedContexts(
-      invariantViews, EntityType.INVARIANT, v => v.invariantId, relationMap, hasNoRelations
+      invariantViews, EntityType.INVARIANT, v => v.invariantId, relationMap
     );
 
     const guidelines = this.toRelatedContexts(
-      guidelineViews, EntityType.GUIDELINE, v => v.guidelineId, relationMap, hasNoRelations
+      guidelineViews, EntityType.GUIDELINE, v => v.guidelineId, relationMap
     );
 
     // 6. Return assembled ContextualGoalView
@@ -138,23 +134,22 @@ export class SqliteGoalContextAssembler implements IGoalContextAssembler {
 
   /**
    * Map entity views to RelatedContext<T> by merging with relation metadata.
-   * Filters out entities without matching relations (unless hasNoRelations).
+   * Filters out entities without matching relations.
    */
   private toRelatedContexts<T>(
     views: T[],
     entityType: string,
     getId: (view: T) => string,
-    relationMap: Map<string, RelationView>,
-    hasNoRelations: boolean
+    relationMap: Map<string, RelationView>
   ): RelatedContext<T>[] {
     return views
       .map((view): RelatedContext<T> | null => {
         const relation = relationMap.get(`${entityType}:${getId(view)}`);
-        if (!relation && !hasNoRelations) return null;
+        if (!relation) return null;
         return {
           entity: view,
-          relationType: relation?.relationType ?? 'default',
-          relationDescription: relation?.description ?? ''
+          relationType: relation.relationType,
+          relationDescription: relation.description ?? ''
         };
       })
       .filter((item): item is RelatedContext<T> => item !== null);

--- a/src/presentation/cli/commands/registry/generated-commands.ts
+++ b/src/presentation/cli/commands/registry/generated-commands.ts
@@ -69,6 +69,7 @@ import { invariantsList, metadata as invariantsListMeta } from '../../commands/i
 import { invariantRemove, metadata as invariantRemoveMeta } from '../../commands/invariants/remove/invariant.remove.js';
 import { invariantUpdate, metadata as invariantUpdateMeta } from '../../commands/invariants/update/invariant.update.js';
 import { dbRebuild, metadata as dbRebuildMeta } from '../../commands/maintenance/db/rebuild/db.rebuild.js';
+import { dependencyMigrate, metadata as dependencyMigrateMeta } from '../../commands/maintenance/migrate-dependencies/dependency.migrate.js';
 import { dbUpgrade, metadata as dbUpgradeMeta } from '../../commands/maintenance/upgrade/db.upgrade.js';
 import { projectInit, metadata as projectInitMeta } from '../../commands/project/init/project.init.js';
 import { projectUpdate, metadata as projectUpdateMeta } from '../../commands/project/update/project.update.js';
@@ -387,6 +388,11 @@ export const commands: RegisteredCommand[] = [
     path: 'db rebuild',
     metadata: dbRebuildMeta,
     handler: dbRebuild
+  },
+  {
+    path: 'dependency migrate',
+    metadata: dependencyMigrateMeta,
+    handler: dependencyMigrate
   },
   {
     path: 'db upgrade',

--- a/tests/infrastructure/context/SqliteGoalContextAssembler.test.ts
+++ b/tests/infrastructure/context/SqliteGoalContextAssembler.test.ts
@@ -24,7 +24,7 @@ import { GuidelineCategory } from "../../../src/domain/guidelines/Constants.js";
  * Tests for SqliteGoalContextAssembler
  *
  * Tests cover:
- * - Default behavior: when no relations exist, fetch all entities
+ * - No-relation behavior: returns empty context collections
  * - Explicit relations: when relations exist, fetch only related entities
  * - Relation metadata mapping into RelatedContext<T>
  * - Architecture handling
@@ -197,7 +197,7 @@ describe("SqliteGoalContextAssembler", () => {
       expect(result).toBeNull();
     });
 
-    it("should return all entities with default relation metadata when no relations exist", async () => {
+    it("should return empty context collections when no relations exist", async () => {
       // Arrange
       const goal: GoalView = {
         goalId: "goal_123",
@@ -313,37 +313,12 @@ describe("SqliteGoalContextAssembler", () => {
       // Assert
       expect(result).not.toBeNull();
       expect(result!.goal).toEqual(goal);
-      expect(result!.context.components).toHaveLength(1);
-      expect(result!.context.components[0]).toEqual({
-        entity: component,
-        relationType: "default",
-        relationDescription: ""
-      });
-      expect(result!.context.dependencies).toHaveLength(1);
-      expect(result!.context.dependencies[0]).toEqual({
-        entity: dependency,
-        relationType: "default",
-        relationDescription: ""
-      });
-      expect(result!.context.decisions).toHaveLength(1);
-      expect(result!.context.decisions[0]).toEqual({
-        entity: decision,
-        relationType: "default",
-        relationDescription: ""
-      });
-      expect(result!.context.invariants).toHaveLength(1);
-      expect(result!.context.invariants[0]).toEqual({
-        entity: invariant,
-        relationType: "default",
-        relationDescription: ""
-      });
-      expect(result!.context.guidelines).toHaveLength(1);
-      expect(result!.context.guidelines[0]).toEqual({
-        entity: guideline,
-        relationType: "default",
-        relationDescription: ""
-      });
-      expect(result!.context.architecture).toEqual(architecture);
+      expect(result!.context.components).toEqual([]);
+      expect(result!.context.dependencies).toEqual([]);
+      expect(result!.context.decisions).toEqual([]);
+      expect(result!.context.invariants).toEqual([]);
+      expect(result!.context.guidelines).toEqual([]);
+      expect(result!.context.architecture).toBeNull();
     });
 
     it("should return only related entities when explicit relations exist", async () => {


### PR DESCRIPTION
  Goals without registered relations now return empty context
  collections instead of fetching all entities. Refinement is
  a prerequisite to starting a goal, so explicit relations are
  guaranteed — the blanket fallback was adding context bloat.
