### PR TITLE
feat: externalize PostHog API key via build-time injection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,5 @@ jobs:
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          POSTHOG_API_KEY: ${{ vars.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}

--- a/build/inject-telemetry-config.mjs
+++ b/build/inject-telemetry-config.mjs
@@ -1,0 +1,65 @@
+/**
+ * Replaces empty-string telemetry defaults in the compiled output with
+ * values from environment variables so the published npm package ships
+ * with the PostHog key and host baked in.
+ *
+ * Runs as a postbuild step: `node build/inject-telemetry-config.mjs`
+ *
+ * Injection is all-or-nothing: both POSTHOG_API_KEY and POSTHOG_HOST
+ * must be set, or neither. Partial configuration fails the build to
+ * prevent half-configured releases.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const constantsPath = path.join(
+  __dirname,
+  "..",
+  "dist",
+  "infrastructure",
+  "telemetry",
+  "PostHogTelemetryConstants.js"
+);
+
+const apiKey = process.env.POSTHOG_API_KEY || "";
+const host = process.env.POSTHOG_HOST || "";
+
+if (!apiKey && !host) {
+  console.log(
+    "ℹ️  POSTHOG_API_KEY and POSTHOG_HOST not set — skipping telemetry injection."
+  );
+  process.exit(0);
+}
+
+if (!apiKey || !host) {
+  console.error(
+    "❌ Partial telemetry configuration: both POSTHOG_API_KEY and POSTHOG_HOST must be set, or neither."
+  );
+  process.exit(1);
+}
+
+if (!fs.existsSync(constantsPath)) {
+  console.error(
+    `❌ Missing ${constantsPath}. Run "npm run build" (tsc) before injecting telemetry config.`
+  );
+  process.exit(1);
+}
+
+let content = fs.readFileSync(constantsPath, "utf-8");
+
+content = content.replace(
+  /const POSTHOG_API_KEY = process\.env\.POSTHOG_API_KEY \|\| ""/,
+  `const POSTHOG_API_KEY = "${apiKey}"`
+);
+
+content = content.replace(
+  /const POSTHOG_HOST = process\.env\.POSTHOG_HOST \|\| ""/,
+  `const POSTHOG_HOST = "${host}"`
+);
+
+fs.writeFileSync(constantsPath, content, "utf-8");
+
+console.log("✅ Telemetry config injected into dist/.");

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "scripts": {
     "generate:commands": "node build/generate-command-registry.mjs",
     "prebuild": "npm run generate:commands",
-    "build": "tsc && npm run copy:migrations",
+    "build": "tsc && npm run copy:migrations && npm run inject:telemetry",
+    "inject:telemetry": "node build/inject-telemetry-config.mjs",
     "copy:migrations": "node build/copy-migrations.mjs",
     "dev": "tsc --watch",
     "test": "jest",

--- a/src/infrastructure/telemetry/PostHogTelemetryClient.ts
+++ b/src/infrastructure/telemetry/PostHogTelemetryClient.ts
@@ -17,7 +17,14 @@ interface IPostHogSdkClient {
   shutdown(shutdownTimeoutMs?: number): void | Promise<void>;
 }
 
-type PostHogClientFactory = () => IPostHogSdkClient;
+type PostHogClientFactory = () => IPostHogSdkClient | null;
+
+function createDefaultPostHogClient(): IPostHogSdkClient | null {
+  if (!POSTHOG_API_KEY) {
+    return null;
+  }
+  return new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+}
 
 export class PostHogTelemetryClient implements ITelemetryClient {
   private readonly anonymousId: string;
@@ -25,8 +32,7 @@ export class PostHogTelemetryClient implements ITelemetryClient {
 
   constructor(
     anonymousId: string,
-    postHogClientFactory: PostHogClientFactory = () =>
-      new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST })
+    postHogClientFactory: PostHogClientFactory = createDefaultPostHogClient
   ) {
     this.anonymousId = anonymousId;
 

--- a/src/infrastructure/telemetry/PostHogTelemetryConstants.ts
+++ b/src/infrastructure/telemetry/PostHogTelemetryConstants.ts
@@ -1,3 +1,3 @@
-export const POSTHOG_API_KEY = "phc_eQVCvdQjhMV6iE1Q8jEnh1vXQw66I1oULPXavgDux5m";
-export const POSTHOG_HOST = "https://eu.i.posthog.com";
+export const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || "";
+export const POSTHOG_HOST = process.env.POSTHOG_HOST || "";
 export const POSTHOG_SHUTDOWN_TIMEOUT_MS = 5000;

--- a/tests/build/inject-telemetry-config.test.ts
+++ b/tests/build/inject-telemetry-config.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+
+const SCRIPT_PATH = path.resolve("build/inject-telemetry-config.mjs");
+
+describe("inject-telemetry-config", () => {
+  let tempDir: string;
+  let constantsDir: string;
+  let constantsPath: string;
+
+  const compiledTemplate = [
+    'export const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || "";',
+    'export const POSTHOG_HOST = process.env.POSTHOG_HOST || "";',
+    "export const POSTHOG_SHUTDOWN_TIMEOUT_MS = 5000;",
+    "",
+  ].join("\n");
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jumbo-inject-"));
+    constantsDir = path.join(
+      tempDir,
+      "dist",
+      "infrastructure",
+      "telemetry"
+    );
+    fs.mkdirSync(constantsDir, { recursive: true });
+    constantsPath = path.join(constantsDir, "PostHogTelemetryConstants.js");
+    fs.writeFileSync(constantsPath, compiledTemplate, "utf-8");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function runScript(env: Record<string, string> = {}): string {
+    // Override the script's __dirname-relative path by symlinking the dist
+    // directory structure. Instead, we run the script from the temp dir
+    // after copying it there and adjusting the path resolution.
+    //
+    // Simpler approach: copy the script into tempDir/build/ so its
+    // __dirname resolution finds tempDir/dist/.
+    const buildDir = path.join(tempDir, "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.copyFileSync(SCRIPT_PATH, path.join(buildDir, "inject-telemetry-config.mjs"));
+
+    return execSync(
+      `node "${path.join(buildDir, "inject-telemetry-config.mjs")}"`,
+      {
+        cwd: tempDir,
+        env: { ...process.env, ...env },
+        encoding: "utf-8",
+      }
+    );
+  }
+
+  it("skips injection when no env vars are set", () => {
+    const output = runScript({
+      POSTHOG_API_KEY: "",
+      POSTHOG_HOST: "",
+    });
+
+    expect(output).toContain("skipping");
+    expect(fs.readFileSync(constantsPath, "utf-8")).toBe(compiledTemplate);
+  });
+
+  it("injects API key and host when both env vars are set", () => {
+    runScript({
+      POSTHOG_API_KEY: "phc_test_key_123",
+      POSTHOG_HOST: "https://eu.posthog.test",
+    });
+
+    const result = fs.readFileSync(constantsPath, "utf-8");
+    expect(result).toContain('const POSTHOG_API_KEY = "phc_test_key_123"');
+    expect(result).toContain('const POSTHOG_HOST = "https://eu.posthog.test"');
+    expect(result).not.toContain("process.env");
+  });
+
+  it("fails when only API key is set without host", () => {
+    expect(() =>
+      runScript({
+        POSTHOG_API_KEY: "phc_only_key",
+        POSTHOG_HOST: "",
+      })
+    ).toThrow();
+
+    expect(fs.readFileSync(constantsPath, "utf-8")).toBe(compiledTemplate);
+  });
+
+  it("fails when only host is set without API key", () => {
+    expect(() =>
+      runScript({
+        POSTHOG_API_KEY: "",
+        POSTHOG_HOST: "https://eu.posthog.test",
+      })
+    ).toThrow();
+
+    expect(fs.readFileSync(constantsPath, "utf-8")).toBe(compiledTemplate);
+  });
+
+  it("preserves POSTHOG_SHUTDOWN_TIMEOUT_MS unchanged", () => {
+    runScript({
+      POSTHOG_API_KEY: "phc_test",
+      POSTHOG_HOST: "https://eu.posthog.test",
+    });
+
+    const result = fs.readFileSync(constantsPath, "utf-8");
+    expect(result).toContain("POSTHOG_SHUTDOWN_TIMEOUT_MS = 5000");
+  });
+
+  it("exits with error when dist file is missing", () => {
+    fs.unlinkSync(constantsPath);
+
+    expect(() =>
+      runScript({
+        POSTHOG_API_KEY: "phc_test",
+        POSTHOG_HOST: "https://eu.posthog.test",
+      })
+    ).toThrow();
+  });
+});

--- a/tests/infrastructure/telemetry/PostHogTelemetryClient.test.ts
+++ b/tests/infrastructure/telemetry/PostHogTelemetryClient.test.ts
@@ -64,7 +64,7 @@ describe("PostHogTelemetryClient", () => {
     await expect(client.shutdown()).resolves.toBeUndefined();
   });
 
-  it("wires PostHogTelemetryClient when telemetry is effectively enabled", async () => {
+  it("wires PostHogTelemetryClient when telemetry is effectively enabled (no-ops without API key)", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "jumbo-telemetry-"));
     const host = new Host(tempDir);
     const savedCiVars: Record<string, string | undefined> = {};
@@ -89,6 +89,10 @@ describe("PostHogTelemetryClient", () => {
 
       const container = await host.createBuilder().build();
 
+      // HostBuilder wires PostHogTelemetryClient when consent is given.
+      // Without POSTHOG_API_KEY in the environment the client silently
+      // no-ops (postHogClient is null), which is the expected local/test
+      // behavior. The published npm package has the key baked in at build time.
       expect(container.telemetryClient).toBeInstanceOf(PostHogTelemetryClient);
     } finally {
       for (const [name, value] of Object.entries(savedCiVars)) {


### PR DESCRIPTION
Remove hardcoded PostHog API key and host from source code. Constants
now read from process.env with empty-string fallback, and a postbuild
script injects the real values during npm publish using GitHub Actions
repository variables. Enforces all-or-nothing configuration to prevent
half-configured releases.
