### PR TITLE
feat: replace proactive guidance with specific context maintenance instructions

### DIFF
--- a/JUMBO.md
+++ b/JUMBO.md
@@ -30,8 +30,38 @@ Run `jumbo session end --focus {focus-description}` --summary {summary-of-what-t
 ### Before Starting Work on a Goal
 Run `jumbo goal start --id <id>`
 
-### Be Proactive - Use Jumbo to the Fullest Extent
-Jumbo supercharges your abilities and consistency by supplying you with durable memory. Use is unsparingly. Be vigilant in identifying user decisions that change the existing standards for the project. Document when new patterns are introduced or removed. Capture corrections made by the user in the form of invariants or guidelines. If a new pattern is introduced, capture it. If a new component is introduced capture it. If new relations are relevant, register them. Use the full jumbo command catalog to quickly gain project insights. The rate of successful collaborations and ability to deliver on the developers wishes without error will highly increase the more you leverage Jumbo.
+### Maintain Context as You Work
+
+Jumbo is your persistent memory across sessions. Keeping it accurate is part of your job — not a cleanup step, but something you do in real-time as you work, the same way you write tests alongside code.
+
+#### During Refinement
+When you discover that work X must happen before a goal can succeed, register it immediately:
+```
+jumbo goal add --objective "X that must happen first"
+jumbo goal update --id <current-goal-id> --prerequisite-goals <new-goal-id>
+```
+
+#### During Implementation
+When you make an architectural decision, register it before moving on:
+```
+jumbo decision add --title "Chose X over Y" --rationale "Because Z" --context "Background"
+```
+
+When you create a new component, register it and link it:
+```
+jumbo component add --name "ComponentName" --description "What it does"
+jumbo relation add --from-type goal --from-id <goal-id> --to-type component --to-id <component-id> --type involves --description "Created during implementation"
+```
+
+#### When the User Corrects You
+When user feedback changes the approach, capture it as a durable constraint:
+```
+jumbo invariant add --category "architecture" --description "Never do X because Y"
+jumbo guideline add --category "codingStyle" --description "Prefer X over Y"
+```
+
+#### Why This Matters
+Context you register now is served to future sessions — yours or another agent's. Unregistered decisions, components, and corrections are lost at session end. The more you capture, the fewer mistakes future sessions make.
 
 ### Available Commands
 `jumbo --help `

--- a/assets/skills/define-jumbo-goals/SKILL.md
+++ b/assets/skills/define-jumbo-goals/SKILL.md
@@ -43,6 +43,13 @@ This discovery serves two purposes:
 - **Inform decomposition**: Understanding the system's boundaries, patterns, and constraints reveals the natural seams along which to split work.
 - **Inform criteria**: Existing invariants, decisions, and patterns dictate what "correct" looks like.
 
+If you encounter components, patterns, or decisions that exist in the codebase but are not registered in Jumbo, register them now — before writing goals. Accurate entity coverage produces better relations during refinement:
+
+```bash
+jumbo component add --name "ExistingService" --description "What it does"
+jumbo decision add --title "Existing pattern" --rationale "Why it was chosen" --context "Background"
+```
+
 Also explore the codebase directly to understand current implementation:
 
 ```bash

--- a/assets/skills/refine-jumbo-goals/SKILL.md
+++ b/assets/skills/refine-jumbo-goals/SKILL.md
@@ -103,15 +103,28 @@ jumbo relation add \
 - GOOD: "Removal must not leave orphaned registrations or broken import paths across layer boundaries"
 - GOOD: "Ensure the read-side query path remains intact after removing the old handler"
 
-### 5. Update Goal Metadata
+### 5. Surface Prerequisites
 
-During entity exploration, you may discover:
+As you analyze the goal against project entities, you may discover that work X must happen before this goal can succeed. When you identify a prerequisite, register it immediately — do not defer it to a note or comment:
+
+1. Register the prerequisite as a new goal:
+   ```bash
+   jumbo goal add --objective "X that must happen first"
+   ```
+2. Link it to the current goal:
+   ```bash
+   jumbo goal update --id <goal-id> --prerequisite-goals <new-goal-id>
+   ```
+3. Continue refining the current goal.
+
+### 6. Update Goal Metadata
+
+During entity exploration, you may also discover:
 - Additional files that belong in scope
 - Files that should be created or modified
 - Risk of scope creep
 - Success criteria that need updating
 - Applicable refactoring skills to reference in criteria (prefix with `skill:`)
-- Registered goals that should be added as prerequisites or follow-ups
 
 Update the goal accordingly:
 
@@ -125,7 +138,7 @@ jumbo goal update --id <goal-id> \
   --prerequisite-goals <goalIds...>
 ```
 
-### 6. Verify Completeness
+### 7. Verify Completeness
 
 Before approving, verify ALL of the following:
 
@@ -138,7 +151,7 @@ Before approving, verify ALL of the following:
 - [ ] Goal criteria and scope reflect any discoveries made during refinement
 - [ ] The goal has at least 5 relations total (fewer suggests incomplete analysis)
 
-### 7. Approve Refinement
+### 8. Approve Refinement
 
 Only after completing all verification checks:
 

--- a/assets/skills/start-jumbo-goal/SKILL.md
+++ b/assets/skills/start-jumbo-goal/SKILL.md
@@ -68,7 +68,30 @@ Coding standards, testing requirements, and process practices. You SHOULD follow
 jumbo goal update-progress --id <goal-id> --task-description "<description>"
 ```
 
-### 4. Submit for Review
+### 4. Maintain Context as You Implement
+
+Register decisions, components, and corrections as they happen — not as a cleanup step after implementation.
+
+- **Architectural decision made** (e.g., chose pattern X over Y):
+  ```bash
+  jumbo decision add --title "Chose X over Y" --rationale "Because Z" --context "Background"
+  ```
+
+- **New component created** (e.g., introduced a new service or builder):
+  ```bash
+  jumbo component add --name "ComponentName" --description "What it does"
+  jumbo relation add --from-type goal --from-id <goal-id> --to-type component --to-id <component-id> --type involves --description "Created during implementation"
+  ```
+
+- **User corrects your approach** (e.g., "don't do X, do Y instead"):
+  ```bash
+  jumbo invariant add --category "architecture" --description "Never do X because Y"
+  jumbo guideline add --category "codingStyle" --description "Prefer X over Y"
+  ```
+
+Context registered now is served to future sessions. What you skip is lost.
+
+### 5. Submit for Review
 
 When all success criteria are met and implementation is complete:
 

--- a/src/domain/project/JumboMdContent.ts
+++ b/src/domain/project/JumboMdContent.ts
@@ -48,8 +48,38 @@ Run \`jumbo session end --focus {focus-description}\` --summary {summary-of-what
 ### Before Starting Work on a Goal
 Run \`jumbo goal start --id <id>\`
 
-### Be Proactive - Use Jumbo to the Fullest Extent
-Jumbo supercharges your abilities and consistency by supplying you with durable memory. Use is unsparingly. Be vigilant in identifying user decisions that change the existing standards for the project. Document when new patterns are introduced or removed. Capture corrections made by the user in the form of invariants or guidelines. If a new pattern is introduced, capture it. If a new component is introduced capture it. If new relations are relevant, register them. Use the full jumbo command catalog to quickly gain project insights. The rate of successful collaborations and ability to deliver on the developers wishes without error will highly increase the more you leverage Jumbo.
+### Maintain Context as You Work
+
+Jumbo is your persistent memory across sessions. Keeping it accurate is part of your job — not a cleanup step, but something you do in real-time as you work, the same way you write tests alongside code.
+
+#### During Refinement
+When you discover that work X must happen before a goal can succeed, register it immediately:
+\`\`\`
+jumbo goal add --objective "X that must happen first"
+jumbo goal update --id <current-goal-id> --prerequisite-goals <new-goal-id>
+\`\`\`
+
+#### During Implementation
+When you make an architectural decision, register it before moving on:
+\`\`\`
+jumbo decision add --title "Chose X over Y" --rationale "Because Z" --context "Background"
+\`\`\`
+
+When you create a new component, register it and link it:
+\`\`\`
+jumbo component add --name "ComponentName" --description "What it does"
+jumbo relation add --from-type goal --from-id <goal-id> --to-type component --to-id <component-id> --type involves --description "Created during implementation"
+\`\`\`
+
+#### When the User Corrects You
+When user feedback changes the approach, capture it as a durable constraint:
+\`\`\`
+jumbo invariant add --category "architecture" --description "Never do X because Y"
+jumbo guideline add --category "codingStyle" --description "Prefer X over Y"
+\`\`\`
+
+#### Why This Matters
+Context you register now is served to future sessions — yours or another agent's. Unregistered decisions, components, and corrections are lost at session end. The more you capture, the fewer mistakes future sessions make.
 
 ### Available Commands
 \`jumbo --help \`

--- a/src/presentation/cli/commands/goals/refine/GoalRefineOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/refine/GoalRefineOutputBuilder.ts
@@ -134,7 +134,13 @@ export class GoalRefineOutputBuilder {
       "Relations capture essential context that will be provided when implementing this goal.\n" +
       "Incomplete relations result in missing architectural constraints, patterns, and domain\n" +
       "knowledge during implementation.\n" +
-      "\nBE THOROUGH: Most goals require 5-10+ relations across multiple entity types."
+      "\nBE THOROUGH: Most goals require 5-10+ relations across multiple entity types.\n" +
+      "\nPREREQUISITE DISCOVERY: As you analyze this goal, if you discover that work X must\n" +
+      "happen before this goal can succeed, stop and register it:\n" +
+      "  1. jumbo goal add --objective \"X that must happen first\"\n" +
+      "  2. jumbo goal update --id " + goal.goalId + " --prerequisite-goals <new-goal-id>\n" +
+      "  3. Continue refinement of this goal\n" +
+      "Do not defer prerequisite registration — capture it the moment you identify it."
     );
 
     // Entity exploration commands

--- a/src/presentation/cli/commands/goals/start/GoalStartOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/start/GoalStartOutputBuilder.ts
@@ -161,7 +161,13 @@ export class GoalStartOutputBuilder {
     this.builder.addPrompt(
       "---\n\n" +
       "@LLM: Goal context loaded. Work within scope.\n" +
-      `Track your progress by documenting completed sub-tasks with 'jumbo goal update-progress --id ${goal.goalId} --task-description <description>'.`
+      `Track your progress by documenting completed sub-tasks with 'jumbo goal update-progress --id ${goal.goalId} --task-description <description>'.\n\n` +
+      "CONTEXT MAINTENANCE: As you implement, register decisions, components, and relations in real-time — not as a cleanup step at the end, but as they happen:\n" +
+      "- When you make an architectural choice: jumbo decision add --title \"Chose X over Y\" --rationale \"Because Z\" --context \"Background\"\n" +
+      "- When you create a new component: jumbo component add --name \"Name\" --description \"What it does\"\n" +
+      "- When you discover a new relation: jumbo relation add --from-type goal --from-id " + goal.goalId + " --to-type <type> --to-id <id> --type involves --description \"Why\"\n" +
+      "- When the user corrects your approach: jumbo invariant add --category \"architecture\" --description \"The constraint\" or jumbo guideline add --category \"codingStyle\" --description \"The practice\"\n" +
+      "Unregistered context is lost at session end. Capture it as it happens."
     );
 
     // Review instructions (prominent)

--- a/src/presentation/cli/commands/sessions/start/SessionContextOutputBuilder.ts
+++ b/src/presentation/cli/commands/sessions/start/SessionContextOutputBuilder.ts
@@ -175,7 +175,7 @@ export class SessionContextOutputBuilder {
 
     const llmInstruction =
       context.context.pausedGoals.length > 0
-        ? "\n\n@LLM: Goals were paused. To resume a paused goal, run:\n  jumbo goal resume --id <goal-id>"
+        ? "\n\n@LLM: Goals were paused in your workspace. To pick up where you left off, run:\n  jumbo goal resume --id <goal-id>"
         : undefined;
 
     return { data: contextData, llmInstruction };
@@ -184,7 +184,8 @@ export class SessionContextOutputBuilder {
   private buildBrownfieldInstruction(): string {
     return [
       "",
-      "@LLM: This is a BROWNFIELD PROJECT with no Jumbo context yet.",
+      "@LLM: This is a BROWNFIELD PROJECT — your Jumbo workspace has no context yet.",
+      "Jumbo is your persistent memory. What you register here survives session boundaries and is available to any agent working on this project.",
       "",
       "REQUIRED ACTION: Proactively engage the user with the following approach:",
       "",

--- a/tests/domain/project/JumboMdContent.test.ts
+++ b/tests/domain/project/JumboMdContent.test.ts
@@ -28,11 +28,21 @@ describe("JumboMdContent Value Object", () => {
       expect(content).toContain("jumbo session start --help");
     });
 
-    it("should include proactive section", () => {
+    it("should include context maintenance section with specific behavioral expectations", () => {
       const content = JumboMdContent.getJumboSection();
 
-      expect(content).toContain("### Be Proactive");
-      expect(content).toContain("Be vigilant in identifying");
+      expect(content).toContain("### Maintain Context as You Work");
+      expect(content).toContain("#### During Refinement");
+      expect(content).toContain("jumbo goal add --objective");
+      expect(content).toContain("--prerequisite-goals");
+      expect(content).toContain("#### During Implementation");
+      expect(content).toContain("jumbo decision add --title");
+      expect(content).toContain("jumbo component add --name");
+      expect(content).toContain("jumbo relation add --from-type goal");
+      expect(content).toContain("#### When the User Corrects You");
+      expect(content).toContain("jumbo invariant add --category");
+      expect(content).toContain("jumbo guideline add --category");
+      expect(content).toContain("#### Why This Matters");
     });
 
     it("should include Dear Agent letter", () => {

--- a/tests/presentation/cli/commands/goals/refine/GoalRefineOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/goals/refine/GoalRefineOutputBuilder.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for GoalRefineOutputBuilder
+ *
+ * Verifies output for goal refine command including:
+ * - Success/error output rendering
+ * - Goal details and refinement prompt
+ * - Prerequisite discovery instructions
+ * - Relation registration instructions
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { GoalRefineOutputBuilder } from "../../../../../../src/presentation/cli/commands/goals/refine/GoalRefineOutputBuilder.js";
+import { GoalView } from "../../../../../../src/application/context/goals/GoalView.js";
+
+describe("GoalRefineOutputBuilder", () => {
+  let builder: GoalRefineOutputBuilder;
+
+  beforeEach(() => {
+    builder = new GoalRefineOutputBuilder();
+  });
+
+  function makeGoal(overrides: Partial<GoalView> = {}): GoalView {
+    return {
+      goalId: "goal_refine_123",
+      title: "Refine Test Goal",
+      objective: "Build feature Y",
+      successCriteria: ["Criterion 1"],
+      scopeIn: ["src/feature/"],
+      scopeOut: ["src/other/"],
+      status: "in-refinement",
+      version: 1,
+      createdAt: "2025-01-01T10:00:00Z",
+      updatedAt: "2025-01-01T10:00:00Z",
+      progress: [],
+      ...overrides,
+    } as GoalView;
+  }
+
+  describe("buildSuccess", () => {
+    it("should render success message", () => {
+      const output = builder.buildSuccess("goal_123", "in-refinement");
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("✓ Goal refinement started");
+    });
+
+    it("should include commit instruction with goal ID", () => {
+      const output = builder.buildSuccess("goal_123", "in-refinement");
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("jumbo goal commit --id goal_123");
+    });
+  });
+
+  describe("buildGoalNotFoundError", () => {
+    it("should render error message with goal ID", () => {
+      const output = builder.buildGoalNotFoundError("goal_missing");
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("✗ Goal not found");
+      expect(text).toContain("goal_missing");
+    });
+  });
+
+  describe("buildFailureError", () => {
+    it("should render failure message from Error", () => {
+      const output = builder.buildFailureError(new Error("Something broke"));
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("✗ Failed to refine goal");
+      expect(text).toContain("Something broke");
+    });
+
+    it("should render failure message from string", () => {
+      const output = builder.buildFailureError("String error");
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("✗ Failed to refine goal");
+      expect(text).toContain("String error");
+    });
+  });
+
+  describe("buildGoalDetailsAndRefinementPrompt", () => {
+    it("should render goal details", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal ID: goal_refine_123");
+      expect(text).toContain("Status: in-refinement");
+      expect(text).toContain("Build feature Y");
+    });
+
+    it("should render success criteria", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("=== Success Criteria ===");
+      expect(text).toContain("Criterion 1");
+    });
+
+    it("should render scope sections", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("=== Scope In ===");
+      expect(text).toContain("src/feature/");
+      expect(text).toContain("=== Scope Out ===");
+      expect(text).toContain("src/other/");
+    });
+
+    it("should include comprehensive relation registration instructions", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("@LLM: CRITICAL");
+      expect(text).toContain("jumbo relation add --from-type goal --from-id goal_refine_123");
+      expect(text).toContain("jumbo goal commit --id goal_refine_123");
+    });
+
+    it("should include prerequisite discovery instructions", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("PREREQUISITE DISCOVERY:");
+      expect(text).toContain("jumbo goal add --objective");
+      expect(text).toContain("jumbo goal update --id goal_refine_123 --prerequisite-goals");
+      expect(text).toContain("Continue refinement of this goal");
+    });
+
+    it("should instruct immediate prerequisite capture", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Do not defer prerequisite registration");
+      expect(text).toContain("capture it the moment you identify it");
+    });
+
+    it("should include entity exploration commands", () => {
+      const goal = makeGoal();
+      const output = builder.buildGoalDetailsAndRefinementPrompt(goal);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("jumbo invariants list");
+      expect(text).toContain("jumbo guidelines list");
+      expect(text).toContain("jumbo decisions list");
+      expect(text).toContain("jumbo components search");
+    });
+  });
+
+  describe("buildInteractiveFlowHeader", () => {
+    it("should render relation registration header", () => {
+      const output = builder.buildInteractiveFlowHeader();
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal Refinement: Register Relations");
+    });
+  });
+
+  describe("buildCreatedRelations", () => {
+    it("should render created relations list", () => {
+      const relations = [
+        { relationType: "involves", toType: "component", toId: "comp_1" },
+        { relationType: "must-respect", toType: "invariant", toId: "inv_1" },
+      ];
+      const output = builder.buildCreatedRelations(relations);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Relations registered:");
+      expect(text).toContain("involves → component:comp_1");
+      expect(text).toContain("must-respect → invariant:inv_1");
+    });
+  });
+});

--- a/tests/presentation/cli/commands/goals/start/GoalStartOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/goals/start/GoalStartOutputBuilder.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for GoalStartOutputBuilder
+ *
+ * Verifies output for goal start command including:
+ * - Goal implementation instructions rendering
+ * - Context maintenance instructions with concrete commands
+ * - Scope, architecture, components, decisions, invariants, guidelines sections
+ * - Progress tracking and submit instructions
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { GoalStartOutputBuilder } from "../../../../../../src/presentation/cli/commands/goals/start/GoalStartOutputBuilder.js";
+import { ContextualGoalView } from "../../../../../../src/application/context/goals/get/ContextualGoalView.js";
+import { GoalView } from "../../../../../../src/application/context/goals/GoalView.js";
+import { GoalContext } from "../../../../../../src/application/context/goals/get/GoalContext.js";
+
+describe("GoalStartOutputBuilder", () => {
+  let builder: GoalStartOutputBuilder;
+
+  beforeEach(() => {
+    builder = new GoalStartOutputBuilder();
+  });
+
+  function makeGoal(overrides: Partial<GoalView> = {}): GoalView {
+    return {
+      goalId: "goal_test_123",
+      title: "Test Goal",
+      objective: "Implement feature X",
+      successCriteria: ["Criterion A", "Criterion B"],
+      scopeIn: [],
+      scopeOut: [],
+      status: "doing",
+      version: 1,
+      createdAt: "2025-01-01T10:00:00Z",
+      updatedAt: "2025-01-01T10:00:00Z",
+      progress: [],
+      ...overrides,
+    } as GoalView;
+  }
+
+  function makeContext(overrides: Partial<GoalContext> = {}): GoalContext {
+    return {
+      components: [],
+      dependencies: [],
+      decisions: [],
+      invariants: [],
+      guidelines: [],
+      architecture: null,
+      ...overrides,
+    };
+  }
+
+  function makeView(
+    goalOverrides: Partial<GoalView> = {},
+    contextOverrides: Partial<GoalContext> = {}
+  ): ContextualGoalView {
+    return {
+      goal: makeGoal(goalOverrides),
+      context: makeContext(contextOverrides),
+    };
+  }
+
+  describe("build", () => {
+    it("should render objective section", () => {
+      const view = makeView();
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("## Objective:");
+      expect(text).toContain("Implement feature X");
+    });
+
+    it("should render success criteria section", () => {
+      const view = makeView();
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("## Success Criteria:");
+      expect(text).toContain("- Criterion A");
+      expect(text).toContain("- Criterion B");
+    });
+
+    it("should render scope sections when scoped", () => {
+      const view = makeView({
+        scopeIn: ["src/feature/"],
+        scopeOut: ["src/other/"],
+      });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("#### In Scope");
+      expect(text).toContain("- src/feature/");
+      expect(text).toContain("#### Out of Scope");
+      expect(text).toContain("- src/other/");
+    });
+
+    it("should render progress section when progress exists", () => {
+      const view = makeView({ progress: ["Completed step 1", "Completed step 2"] });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("## Current Progress:");
+      expect(text).toContain("- Completed step 1");
+      expect(text).toContain("- Completed step 2");
+    });
+
+    it("should include submit instruction with goal ID", () => {
+      const view = makeView({ goalId: "goal_abc" });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("jumbo goal submit --id goal_abc");
+    });
+
+    it("should include progress tracking instruction with goal ID", () => {
+      const view = makeView({ goalId: "goal_abc" });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("jumbo goal update-progress --id goal_abc");
+    });
+  });
+
+  describe("context maintenance instructions", () => {
+    it("should include context maintenance section with concrete commands", () => {
+      const view = makeView();
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("CONTEXT MAINTENANCE:");
+      expect(text).toContain("jumbo decision add --title");
+      expect(text).toContain("jumbo component add --name");
+      expect(text).toContain("jumbo relation add --from-type goal --from-id goal_test_123");
+      expect(text).toContain("jumbo invariant add --category");
+      expect(text).toContain("jumbo guideline add --category");
+    });
+
+    it("should emphasize real-time registration over cleanup", () => {
+      const view = makeView();
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("not as a cleanup step at the end");
+      expect(text).toContain("Capture it as it happens");
+    });
+
+    it("should include goal-specific relation add command with correct goal ID", () => {
+      const view = makeView({ goalId: "goal_specific_456" });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("--from-id goal_specific_456");
+    });
+  });
+
+  describe("components section", () => {
+    it("should render components when present", () => {
+      const view = makeView({}, {
+        components: [
+          { entity: { name: "AuthService", description: "Handles authentication" } as any, relationType: "involves", relationDescription: "" },
+        ],
+      });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("## Relevant Components:");
+      expect(text).toContain("AuthService: Handles authentication");
+    });
+  });
+
+  describe("decisions section", () => {
+    it("should render decisions when present", () => {
+      const view = makeView({}, {
+        decisions: [
+          { entity: { title: "Use REST", rationale: "Simpler than GraphQL" } as any, relationType: "implements", relationDescription: "" },
+        ],
+      });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("## Relevant Decisions:");
+      expect(text).toContain("Use REST: Simpler than GraphQL");
+    });
+  });
+
+  describe("invariants section", () => {
+    it("should render invariants when present", () => {
+      const view = makeView({}, {
+        invariants: [
+          { entity: { title: "No raw SQL", description: "Always use query builder" } as any, relationType: "must-respect", relationDescription: "" },
+        ],
+      });
+      const output = builder.build(view);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("## Invariants:");
+      expect(text).toContain("No raw SQL:");
+      expect(text).toContain("Always use query builder");
+    });
+  });
+});

--- a/tests/presentation/cli/commands/sessions/start/SessionContextOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/sessions/start/SessionContextOutputBuilder.test.ts
@@ -163,11 +163,38 @@ describe("SessionContextOutputBuilder", () => {
       expect(text).toContain("jumbo goal resume --id");
     });
 
-    it("should not include @LLM resume prompt when no goals are paused", () => {
+    it("should not include resume prompt when no goals are paused", () => {
       const context = createContext({ pausedGoals: [] });
       const text = builder.renderSessionSummary(context);
 
       expect(text).not.toContain("Goals were paused");
+    });
+
+    it("should frame paused goals with workspace language", () => {
+      const context = createContext({
+        pausedGoals: [
+          {
+            goalId: "goal_ws",
+            objective: "Workspace task",
+            status: "paused",
+            updatedAt: "2025-01-01T11:15:00Z",
+          } as GoalView,
+        ],
+      });
+
+      const text = builder.renderSessionSummary(context);
+
+      expect(text).toContain("your workspace");
+    });
+  });
+
+  describe("brownfield workspace framing", () => {
+    it("should frame Jumbo as the LLM's persistent memory in brownfield onboarding", () => {
+      const context = createContext({}, defaultSession, ["brownfield-onboarding"]);
+      const text = builder.renderSessionSummary(context);
+
+      expect(text).toContain("your Jumbo workspace");
+      expect(text).toContain("your persistent memory");
     });
   });
 


### PR DESCRIPTION
Rewrite agent behavioral guidance to give concrete, actionable instructions
for maintaining Jumbo context during refinement, implementation, and session
start — replacing the vague "be proactive" section with specific triggers
and commands for prerequisite discovery, decision capture, and entity registration.
