### PR TITLE
feat: surface activity mirror at session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Activity mirror**: `session start` now surfaces a brief summary of proactive context maintenance actions from recent sessions (entities registered, decisions recorded, relations added, goals added), reinforcing productive LLM behavior.
+
 ## [2.3.1] - 2026-03-21
 
 ### Changed

--- a/src/application/context/sessions/start/ActivityMirrorAssembler.ts
+++ b/src/application/context/sessions/start/ActivityMirrorAssembler.ts
@@ -1,0 +1,81 @@
+import { IEventStore } from "../../../persistence/IEventStore.js";
+
+/**
+ * ActivityMirror - Summary of proactive context maintenance actions
+ * taken during recent sessions.
+ */
+export interface ActivityMirror {
+  readonly sessionCount: number;
+  readonly entitiesRegistered: number;
+  readonly decisionsRecorded: number;
+  readonly relationsAdded: number;
+  readonly goalsAdded: number;
+}
+
+const ENTITY_ADD_EVENTS = new Set([
+  "ComponentAddedEvent",
+  "InvariantAddedEvent",
+  "GuidelineAddedEvent",
+]);
+
+const SESSION_LOOKBACK = 3;
+
+/**
+ * ActivityMirrorAssembler - Assembles a summary of proactive context
+ * maintenance actions from recent sessions.
+ *
+ * Follows the query-time assembly pattern (dec_a6bd3bba): no new projections
+ * or tables. Activity data is computed from existing events at query time.
+ */
+export class ActivityMirrorAssembler {
+  constructor(private readonly eventStore: IEventStore) {}
+
+  async assemble(): Promise<ActivityMirror | null> {
+    const allEvents = await this.eventStore.getAllEvents();
+
+    const sessionStarts = allEvents.filter(
+      (e) => e.type === "SessionStartedEvent"
+    );
+
+    if (sessionStarts.length === 0) {
+      return null;
+    }
+
+    const lookbackCount = Math.min(SESSION_LOOKBACK, sessionStarts.length);
+    const cutoffTimestamp =
+      sessionStarts[sessionStarts.length - lookbackCount].timestamp;
+
+    let entitiesRegistered = 0;
+    let decisionsRecorded = 0;
+    let relationsAdded = 0;
+    let goalsAdded = 0;
+
+    for (const event of allEvents) {
+      if (event.timestamp < cutoffTimestamp) continue;
+
+      if (ENTITY_ADD_EVENTS.has(event.type)) {
+        entitiesRegistered++;
+      } else if (event.type === "DecisionAddedEvent") {
+        decisionsRecorded++;
+      } else if (event.type === "RelationAddedEvent") {
+        relationsAdded++;
+      } else if (event.type === "GoalAddedEvent") {
+        goalsAdded++;
+      }
+    }
+
+    const total =
+      entitiesRegistered + decisionsRecorded + relationsAdded + goalsAdded;
+    if (total === 0) {
+      return null;
+    }
+
+    return {
+      sessionCount: lookbackCount,
+      entitiesRegistered,
+      decisionsRecorded,
+      relationsAdded,
+      goalsAdded,
+    };
+  }
+}

--- a/src/application/context/sessions/start/LocalStartSessionGateway.ts
+++ b/src/application/context/sessions/start/LocalStartSessionGateway.ts
@@ -5,12 +5,14 @@ import { StartSessionCommandHandler } from "./StartSessionCommandHandler.js";
 import { SessionContextQueryHandler } from "../get/SessionContextQueryHandler.js";
 import { IBrownfieldStatusReader } from "./IBrownfieldStatusReader.js";
 import { ContextualSessionView } from "../get/ContextualSessionView.js";
+import { ActivityMirrorAssembler } from "./ActivityMirrorAssembler.js";
 
 export class LocalStartSessionGateway implements IStartSessionGateway {
   constructor(
     private readonly sessionContextQueryHandler: SessionContextQueryHandler,
     private readonly startSessionCommandHandler: StartSessionCommandHandler,
-    private readonly brownfieldStatusReader: IBrownfieldStatusReader
+    private readonly brownfieldStatusReader: IBrownfieldStatusReader,
+    private readonly activityMirrorAssembler: ActivityMirrorAssembler
   ) {}
 
   async startSession(request: SessionStartRequest): Promise<SessionStartResponse> {
@@ -23,10 +25,13 @@ export class LocalStartSessionGateway implements IStartSessionGateway {
     // 3. Build start-specific instructions
     const instructions = this.buildStartInstructions(contextualSessionView, isUnprimed);
 
-    // 4. Execute session start command
+    // 4. Assemble activity mirror (before session start event is written)
+    const activityMirror = await this.activityMirrorAssembler.assemble();
+
+    // 5. Execute session start command
     const result = await this.startSessionCommandHandler.execute({});
 
-    // 5. Return enriched context with session ID
+    // 6. Return enriched context with session ID and activity mirror
     return {
       context: {
         ...contextualSessionView,
@@ -34,6 +39,7 @@ export class LocalStartSessionGateway implements IStartSessionGateway {
         scope: "session-start",
       },
       sessionId: result.sessionId,
+      activityMirror,
     };
   }
 

--- a/src/application/context/sessions/start/SessionStartResponse.ts
+++ b/src/application/context/sessions/start/SessionStartResponse.ts
@@ -1,12 +1,14 @@
 import { EnrichedSessionContext } from "../get/EnrichedSessionContext.js";
+import { ActivityMirror } from "./ActivityMirrorAssembler.js";
 
 /**
  * SessionStartResponse - Result of starting a new session.
  *
- * Contains the enriched session context (with LLM instruction signals)
- * and the newly created session ID.
+ * Contains the enriched session context (with LLM instruction signals),
+ * the newly created session ID, and an optional activity mirror summary.
  */
 export interface SessionStartResponse {
   readonly context: EnrichedSessionContext;
   readonly sessionId: string;
+  readonly activityMirror: ActivityMirror | null;
 }

--- a/src/infrastructure/host/HostBuilder.ts
+++ b/src/infrastructure/host/HostBuilder.ts
@@ -481,6 +481,7 @@ import { UpdateTelemetryConsentCommandHandler } from "../../application/context/
 import { LocalUpdateTelemetryConsentGateway } from "../../application/context/telemetry/update/LocalUpdateTelemetryConsentGateway.js";
 import { UpdateTelemetryConsentController } from "../../application/context/telemetry/update/UpdateTelemetryConsentController.js";
 import { LocalStartSessionGateway } from "../../application/context/sessions/start/LocalStartSessionGateway.js";
+import { ActivityMirrorAssembler } from "../../application/context/sessions/start/ActivityMirrorAssembler.js";
 import { EndSessionController } from "../../application/context/sessions/end/EndSessionController.js";
 import { LocalEndSessionGateway } from "../../application/context/sessions/end/LocalEndSessionGateway.js";
 import { EndSessionCommandHandler } from "../../application/context/sessions/end/EndSessionCommandHandler.js";
@@ -975,10 +976,12 @@ const audiencePainContextReader = new SqliteAudiencePainContextReader(this.db);
       sessionStartedEventStore,
       eventBus
     );
+    const activityMirrorAssembler = new ActivityMirrorAssembler(eventStore);
     const startSessionGateway = new LocalStartSessionGateway(
       sessionContextQueryHandler,
       startSessionCommandHandler,
-      brownfieldStatusReader
+      brownfieldStatusReader,
+      activityMirrorAssembler
     );
     const sessionStartController = new SessionStartController(
       startSessionGateway

--- a/src/presentation/cli/commands/sessions/start/SessionStartOutputBuilder.ts
+++ b/src/presentation/cli/commands/sessions/start/SessionStartOutputBuilder.ts
@@ -3,6 +3,7 @@ import { TerminalOutput } from "../../../output/TerminalOutput.js";
 import { EnrichedSessionContext } from "../../../../../application/context/sessions/get/EnrichedSessionContext.js";
 import { SessionContextOutputBuilder } from "./SessionContextOutputBuilder.js";
 import { SessionGoalsOutputBuilder } from "./SessionGoalsOutputBuilder.js";
+import { ActivityMirror } from "../../../../../application/context/sessions/start/ActivityMirrorAssembler.js";
 /**
  * SessionStartOutputBuilder - Top-level output builder for session start command.
  *
@@ -24,9 +25,9 @@ export class SessionStartOutputBuilder {
 
   /**
    * Build complete human-readable session start output.
-   * Composes project context, session summary, goals, and LLM instructions.
+   * Composes project context, activity mirror, session summary, goals, and LLM instructions.
    */
-  buildSessionStartOutput(context: EnrichedSessionContext): TerminalOutput {
+  buildSessionStartOutput(context: EnrichedSessionContext, activityMirror?: ActivityMirror | null): TerminalOutput {
     this.builder.reset();
 
     const contextOutput = this.sessionContextOutputBuilder.buildSessionContext(context);
@@ -34,6 +35,10 @@ export class SessionStartOutputBuilder {
       if (section.type === "prompt" && section.content) {
         this.builder.addPrompt(section.content as string);
       }
+    }
+
+    if (activityMirror) {
+      this.builder.addPrompt(this.renderActivityMirror(activityMirror));
     }
 
     const allGoals = [
@@ -54,7 +59,7 @@ export class SessionStartOutputBuilder {
   /**
    * Build structured JSON output for session start command.
    */
-  buildStructuredOutput(context: EnrichedSessionContext, sessionId: string): Record<string, unknown> {
+  buildStructuredOutput(context: EnrichedSessionContext, sessionId: string, activityMirror?: ActivityMirror | null): Record<string, unknown> {
     const allGoals = [
       ...context.context.activeGoals,
       ...context.context.pausedGoals,
@@ -64,7 +69,7 @@ export class SessionStartOutputBuilder {
     const contextData = this.sessionContextOutputBuilder.buildStructuredSessionContext(context);
     const goalsData = this.sessionGoalsOutputBuilder.buildStructuredGoals(allGoals);
 
-    return {
+    const result: Record<string, unknown> = {
       projectContext: contextData.projectContext,
       sessionContext: contextData.sessionContext,
       goals: goalsData.goals,
@@ -76,5 +81,31 @@ export class SessionStartOutputBuilder {
         sessionId,
       },
     };
+
+    if (activityMirror) {
+      result.activityMirror = activityMirror;
+    }
+
+    return result;
+  }
+
+  private renderActivityMirror(mirror: ActivityMirror): string {
+    const parts: string[] = [];
+
+    if (mirror.entitiesRegistered > 0) {
+      parts.push(`${mirror.entitiesRegistered} entities registered`);
+    }
+    if (mirror.decisionsRecorded > 0) {
+      parts.push(`${mirror.decisionsRecorded} decisions recorded`);
+    }
+    if (mirror.relationsAdded > 0) {
+      parts.push(`${mirror.relationsAdded} relations added`);
+    }
+    if (mirror.goalsAdded > 0) {
+      parts.push(`${mirror.goalsAdded} goals added`);
+    }
+
+    return `[Activity Mirror] Last ${mirror.sessionCount} sessions: ${parts.join(", ")}\n` +
+      `@LLM: This is your impact. These context maintenance actions you took are now available to all future sessions and agents on this project. Keep it up.`;
   }
 }

--- a/src/presentation/cli/commands/sessions/start/session.start.ts
+++ b/src/presentation/cli/commands/sessions/start/session.start.ts
@@ -56,14 +56,14 @@ export async function sessionStart(
     const outputBuilder = new SessionStartOutputBuilder();
 
     if (isTextOutput) {
-      const output = outputBuilder.buildSessionStartOutput(response.context);
+      const output = outputBuilder.buildSessionStartOutput(response.context, response.activityMirror);
       renderer.info(output.toHumanReadable());
 
       renderer.success("Session started", {
         sessionId: response.sessionId,
       });
     } else {
-      renderer.data(outputBuilder.buildStructuredOutput(response.context, response.sessionId));
+      renderer.data(outputBuilder.buildStructuredOutput(response.context, response.sessionId, response.activityMirror));
     }
   } catch (error) {
     renderer.error("Failed to start session", error instanceof Error ? error : String(error));

--- a/tests/application/context/sessions/start/ActivityMirrorAssembler.test.ts
+++ b/tests/application/context/sessions/start/ActivityMirrorAssembler.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { ActivityMirrorAssembler } from "../../../../../src/application/context/sessions/start/ActivityMirrorAssembler.js";
+import { IEventStore } from "../../../../../src/application/persistence/IEventStore.js";
+import { BaseEvent } from "../../../../../src/domain/BaseEvent.js";
+
+describe("ActivityMirrorAssembler", () => {
+  let eventStore: jest.Mocked<IEventStore>;
+  let assembler: ActivityMirrorAssembler;
+
+  beforeEach(() => {
+    eventStore = {
+      getAllEvents: jest.fn().mockResolvedValue([]),
+      append: jest.fn(),
+      readStream: jest.fn(),
+    } as jest.Mocked<IEventStore>;
+    assembler = new ActivityMirrorAssembler(eventStore);
+  });
+
+  function event(type: string, timestamp: string): BaseEvent {
+    return {
+      type,
+      aggregateId: `agg-${Math.random().toString(36).slice(2, 8)}`,
+      version: 1,
+      timestamp,
+    };
+  }
+
+  it("should return null when no session start events exist", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("ComponentAddedEvent", "2025-01-01T10:00:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when no proactive actions exist in lookback window", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("SessionEndedEvent", "2025-01-01T11:00:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result).toBeNull();
+  });
+
+  it("should count entity registrations (components, invariants, guidelines)", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("ComponentAddedEvent", "2025-01-01T10:01:00Z"),
+      event("InvariantAddedEvent", "2025-01-01T10:02:00Z"),
+      event("GuidelineAddedEvent", "2025-01-01T10:03:00Z"),
+      event("ComponentAddedEvent", "2025-01-01T10:04:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result).not.toBeNull();
+    expect(result!.entitiesRegistered).toBe(4);
+  });
+
+  it("should count decisions separately from entities", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("DecisionAddedEvent", "2025-01-01T10:01:00Z"),
+      event("DecisionAddedEvent", "2025-01-01T10:02:00Z"),
+      event("ComponentAddedEvent", "2025-01-01T10:03:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result!.decisionsRecorded).toBe(2);
+    expect(result!.entitiesRegistered).toBe(1);
+  });
+
+  it("should count relation and goal additions", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("RelationAddedEvent", "2025-01-01T10:01:00Z"),
+      event("RelationAddedEvent", "2025-01-01T10:02:00Z"),
+      event("RelationAddedEvent", "2025-01-01T10:03:00Z"),
+      event("GoalAddedEvent", "2025-01-01T10:04:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result!.relationsAdded).toBe(3);
+    expect(result!.goalsAdded).toBe(1);
+  });
+
+  it("should only count events from the last 3 sessions", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      // Session 1 - outside lookback
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("ComponentAddedEvent", "2025-01-01T10:01:00Z"),
+      // Session 2
+      event("SessionStartedEvent", "2025-01-02T10:00:00Z"),
+      event("ComponentAddedEvent", "2025-01-02T10:01:00Z"),
+      // Session 3
+      event("SessionStartedEvent", "2025-01-03T10:00:00Z"),
+      event("DecisionAddedEvent", "2025-01-03T10:01:00Z"),
+      // Session 4
+      event("SessionStartedEvent", "2025-01-04T10:00:00Z"),
+      event("GoalAddedEvent", "2025-01-04T10:01:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    // Last 3 sessions: 2, 3, 4. Session 1 component excluded.
+    expect(result!.sessionCount).toBe(3);
+    expect(result!.entitiesRegistered).toBe(1); // only session 2 component
+    expect(result!.decisionsRecorded).toBe(1);
+    expect(result!.goalsAdded).toBe(1);
+  });
+
+  it("should use fewer sessions when less than 3 exist", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("ComponentAddedEvent", "2025-01-01T10:01:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result!.sessionCount).toBe(1);
+    expect(result!.entitiesRegistered).toBe(1);
+  });
+
+  it("should ignore non-proactive event types", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("ComponentUpdatedEvent", "2025-01-01T10:01:00Z"),
+      event("DecisionReversedEvent", "2025-01-01T10:02:00Z"),
+      event("GoalStartedEvent", "2025-01-01T10:03:00Z"),
+      event("SessionEndedEvent", "2025-01-01T11:00:00Z"),
+      event("ComponentAddedEvent", "2025-01-01T10:04:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    expect(result!.entitiesRegistered).toBe(1);
+    expect(result!.decisionsRecorded).toBe(0);
+    expect(result!.relationsAdded).toBe(0);
+    expect(result!.goalsAdded).toBe(0);
+  });
+
+  it("should exclude events before the lookback cutoff", async () => {
+    eventStore.getAllEvents.mockResolvedValue([
+      event("ComponentAddedEvent", "2024-12-01T10:00:00Z"), // before any session
+      event("SessionStartedEvent", "2025-01-01T10:00:00Z"),
+      event("DecisionAddedEvent", "2025-01-01T10:01:00Z"),
+    ]);
+
+    const result = await assembler.assemble();
+
+    // Only the decision after session start should count
+    expect(result!.entitiesRegistered).toBe(0);
+    expect(result!.decisionsRecorded).toBe(1);
+  });
+});

--- a/tests/application/context/sessions/start/LocalStartSessionGateway.test.ts
+++ b/tests/application/context/sessions/start/LocalStartSessionGateway.test.ts
@@ -3,6 +3,7 @@ import { LocalStartSessionGateway } from "../../../../../src/application/context
 import { SessionContextQueryHandler } from "../../../../../src/application/context/sessions/get/SessionContextQueryHandler.js";
 import { StartSessionCommandHandler } from "../../../../../src/application/context/sessions/start/StartSessionCommandHandler.js";
 import { IBrownfieldStatusReader } from "../../../../../src/application/context/sessions/start/IBrownfieldStatusReader.js";
+import { ActivityMirrorAssembler } from "../../../../../src/application/context/sessions/start/ActivityMirrorAssembler.js";
 import { ContextualSessionView } from "../../../../../src/application/context/sessions/get/ContextualSessionView.js";
 import { GoalView } from "../../../../../src/application/context/goals/GoalView.js";
 
@@ -10,6 +11,7 @@ describe("LocalStartSessionGateway", () => {
   let sessionContextQueryHandler: jest.Mocked<SessionContextQueryHandler>;
   let startSessionCommandHandler: jest.Mocked<StartSessionCommandHandler>;
   let brownfieldStatusReader: jest.Mocked<IBrownfieldStatusReader>;
+  let activityMirrorAssembler: jest.Mocked<ActivityMirrorAssembler>;
   let gateway: LocalStartSessionGateway;
 
   function createBaseContextView(
@@ -42,10 +44,15 @@ describe("LocalStartSessionGateway", () => {
       isUnprimed: jest.fn().mockResolvedValue(false),
     } as jest.Mocked<IBrownfieldStatusReader>;
 
+    activityMirrorAssembler = {
+      assemble: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<ActivityMirrorAssembler>;
+
     gateway = new LocalStartSessionGateway(
       sessionContextQueryHandler,
       startSessionCommandHandler,
-      brownfieldStatusReader
+      brownfieldStatusReader,
+      activityMirrorAssembler
     );
   });
 
@@ -144,6 +151,47 @@ describe("LocalStartSessionGateway", () => {
         "paused-goals-resume",
         "goal-selection-prompt",
       ]);
+    });
+  });
+
+  describe("activity mirror", () => {
+    it("should include activity mirror from assembler", async () => {
+      const mirror = {
+        sessionCount: 3,
+        entitiesRegistered: 5,
+        decisionsRecorded: 2,
+        relationsAdded: 1,
+        goalsAdded: 1,
+      };
+      activityMirrorAssembler.assemble.mockResolvedValue(mirror);
+
+      const result = await gateway.startSession({});
+
+      expect(result.activityMirror).toBe(mirror);
+    });
+
+    it("should return null activity mirror when assembler returns null", async () => {
+      activityMirrorAssembler.assemble.mockResolvedValue(null);
+
+      const result = await gateway.startSession({});
+
+      expect(result.activityMirror).toBeNull();
+    });
+
+    it("should call assembler before session start command", async () => {
+      const callOrder: string[] = [];
+      activityMirrorAssembler.assemble.mockImplementation(async () => {
+        callOrder.push("assemble");
+        return null;
+      });
+      startSessionCommandHandler.execute.mockImplementation(async () => {
+        callOrder.push("startSession");
+        return { sessionId: "session_test-123" };
+      });
+
+      await gateway.startSession({});
+
+      expect(callOrder).toEqual(["assemble", "startSession"]);
     });
   });
 

--- a/tests/presentation/cli/commands/sessions/start/SessionStartOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/sessions/start/SessionStartOutputBuilder.test.ts
@@ -15,6 +15,7 @@ import { SessionContext } from "../../../../../../src/application/context/sessio
 import { GoalView } from "../../../../../../src/application/context/goals/GoalView.js";
 import { DecisionView } from "../../../../../../src/application/context/decisions/DecisionView.js";
 import { SessionView } from "../../../../../../src/application/context/sessions/SessionView.js";
+import { ActivityMirror } from "../../../../../../src/application/context/sessions/start/ActivityMirrorAssembler.js";
 
 describe("SessionStartOutputBuilder", () => {
   let builder: SessionStartOutputBuilder;
@@ -167,6 +168,87 @@ describe("SessionStartOutputBuilder", () => {
       const result = builder.buildStructuredOutput(context, "session-000");
 
       expect(result.llmInstructions.sessionContext).toBeNull();
+    });
+
+    it("should include activityMirror in structured output when provided", () => {
+      const context = createContext();
+      const mirror: ActivityMirror = {
+        sessionCount: 3,
+        entitiesRegistered: 5,
+        decisionsRecorded: 2,
+        relationsAdded: 3,
+        goalsAdded: 1,
+      };
+
+      const result = builder.buildStructuredOutput(context, "session-123", mirror);
+
+      expect(result.activityMirror).toEqual(mirror);
+    });
+
+    it("should omit activityMirror from structured output when null", () => {
+      const context = createContext();
+      const result = builder.buildStructuredOutput(context, "session-123", null);
+
+      expect(result).not.toHaveProperty("activityMirror");
+    });
+  });
+
+  describe("activity mirror rendering", () => {
+    it("should render activity mirror section when provided", () => {
+      const context = createContext();
+      const mirror: ActivityMirror = {
+        sessionCount: 3,
+        entitiesRegistered: 8,
+        decisionsRecorded: 3,
+        relationsAdded: 2,
+        goalsAdded: 1,
+      };
+
+      const output = builder.buildSessionStartOutput(context, mirror);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("[Activity Mirror]");
+      expect(text).toContain("Last 3 sessions");
+      expect(text).toContain("8 entities registered");
+      expect(text).toContain("3 decisions recorded");
+      expect(text).toContain("2 relations added");
+      expect(text).toContain("1 goals added");
+      expect(text).toContain("@LLM: This is your impact");
+    });
+
+    it("should omit activity mirror section when null", () => {
+      const context = createContext();
+      const output = builder.buildSessionStartOutput(context, null);
+      const text = output.toHumanReadable();
+
+      expect(text).not.toContain("[Activity Mirror]");
+    });
+
+    it("should omit activity mirror section when not provided", () => {
+      const context = createContext();
+      const output = builder.buildSessionStartOutput(context);
+      const text = output.toHumanReadable();
+
+      expect(text).not.toContain("[Activity Mirror]");
+    });
+
+    it("should only include non-zero counts in activity mirror", () => {
+      const context = createContext();
+      const mirror: ActivityMirror = {
+        sessionCount: 2,
+        entitiesRegistered: 3,
+        decisionsRecorded: 0,
+        relationsAdded: 0,
+        goalsAdded: 1,
+      };
+
+      const output = builder.buildSessionStartOutput(context, mirror);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("3 entities registered");
+      expect(text).toContain("1 goals added");
+      expect(text).not.toContain("decisions");
+      expect(text).not.toContain("relations");
     });
   });
 });


### PR DESCRIPTION
Show a summary of proactive context maintenance actions from recent
sessions (entities registered, decisions recorded, relations added,
goals added) to reinforce productive LLM behavior.
