### PR TITLE
chore: release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-03-27
+
 ### Added
 
 - **Interactive agent selection in init**: `jumbo init` now presents a checkbox prompt for Claude, Gemini, Copilot, and GitHub Hooks before confirmation. Planned changes, agent-specific files, and template-managed skills are filtered to the selected agents, while non-interactive mode still configures all agents.
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Internal**: Logging now writes daily log files (`yyyyddmm.log`) instead of a single unbounded `jumbo.log` file.
+- **Internal**: Disconnected ActivityMirror from session start output to eliminate a full event store scan (~12,500 file reads) that was causing sluggish `session start` performance. Backend assembler preserved for future use.
 
 ## [2.5.0] - 2026-03-26
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [2.6.0] - 2026-03-27

### Added

- **Interactive agent selection in init**: `jumbo init` now presents a checkbox prompt for Claude, Gemini, Copilot, and GitHub Hooks before confirmation. Planned changes, agent-specific files, and template-managed skills are filtered to the selected agents, while non-interactive mode still configures all agents.

### Changed

- **Internal**: Logging now writes daily log files (`yyyyddmm.log`) instead of a single unbounded `jumbo.log` file.
- **Internal**: Disconnected ActivityMirror from session start output to eliminate a full event store scan (~12,500 file reads) that was causing sluggish `session start` performance. Backend assembler preserved for future use.