### PR TITLE
feat: add --continue flag to cross-phase transition commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--continue` flag for cross-phase commands**: `goal commit`, `goal submit`, `goal approve`, `goal reject`, and `goal close` now accept `-c, --continue`. Without the flag, next-step output is informational guidance; with it, output is an imperative directive. This makes phase boundaries explicit handoff points for multi-agent harnesses.
+
 ## [2.10.0] - 2026-04-05
 
 ### Added

--- a/docs/guides/advanced-workflows.md
+++ b/docs/guides/advanced-workflows.md
@@ -29,6 +29,23 @@ Tips:
 - If QA finds issues, use `jumbo goal reject --id <goalId> --audit-findings "..."`, fix, then `submit` again.
 - `jumbo goal qualify --id <goalId>` exists for backward compatibility but is deprecated in favor of `goal approve`.
 
+## Control phase handoffs with --continue
+
+Cross-phase transition commands (`commit`, `submit`, `approve`, `reject`, `close`) accept a `--continue` flag that changes how next-step output is framed.
+
+- **Without `--continue`** (default): output names the upcoming phase and command as informational guidance. The agent stops at the phase boundary.
+- **With `--continue`**: output is an imperative directive, telling the agent to proceed immediately.
+
+Use the default when different agents or models handle different phases (e.g., a cheaper model refines, a stronger model implements, a dedicated reviewer approves). Use `--continue` when a single agent should drive through multiple phases without stopping.
+
+```bash
+# Multi-agent: implementer stops after submit, reviewer picks up separately
+> jumbo goal submit --id <goalId>
+
+# Single-agent: implementer continues straight into review
+> jumbo goal submit --id <goalId> --continue
+```
+
 ## Run multiple agents in parallel safely
 
 Jumbo supports concurrent workers in separate terminals.

--- a/docs/reference/commands/goal.md
+++ b/docs/reference/commands/goal.md
@@ -87,7 +87,7 @@ Commit a goal after refinement is complete — transitions from `in-refinement` 
 ### Synopsis
 
 ```bash
-> jumbo goal commit --id <goalId>
+> jumbo goal commit --id <goalId> [--continue]
 ```
 
 ### Options
@@ -95,11 +95,13 @@ Commit a goal after refinement is complete — transitions from `in-refinement` 
 | Option | Description |
 |--------|-------------|
 | `-i, --id <goalId>` | ID of the goal to commit (required) |
+| `-c, --continue` | Output next-step as a directive instead of informational guidance |
 
 ### Examples
 
 ```bash
 > jumbo goal commit --id goal_abc123
+> jumbo goal commit --id goal_abc123 --continue
 ```
 
 ---
@@ -244,7 +246,7 @@ Submit a goal after implementation is complete — transitions from `doing` to `
 ### Synopsis
 
 ```bash
-> jumbo goal submit --id <goalId>
+> jumbo goal submit --id <goalId> [--continue]
 ```
 
 ### Options
@@ -252,11 +254,13 @@ Submit a goal after implementation is complete — transitions from `doing` to `
 | Option | Description |
 |--------|-------------|
 | `-i, --id <goalId>` | ID of the goal to submit (required) |
+| `-c, --continue` | Output next-step as a directive instead of informational guidance |
 
 ### Examples
 
 ```bash
 > jumbo goal submit --id goal_abc123
+> jumbo goal submit --id goal_abc123 --continue
 ```
 
 ---
@@ -292,7 +296,7 @@ Approve a goal after successful QA review — transitions from `in-review` to `a
 ### Synopsis
 
 ```bash
-> jumbo goal approve --id <goalId>
+> jumbo goal approve --id <goalId> [--continue]
 ```
 
 ### Options
@@ -300,11 +304,13 @@ Approve a goal after successful QA review — transitions from `in-review` to `a
 | Option | Description |
 |--------|-------------|
 | `-i, --id <goalId>` | ID of the goal to approve (required) |
+| `-c, --continue` | Output next-step as a directive instead of informational guidance |
 
 ### Examples
 
 ```bash
 > jumbo goal approve --id goal_abc123
+> jumbo goal approve --id goal_abc123 --continue
 ```
 
 ---
@@ -340,7 +346,7 @@ Reject a goal after failed QA review — transitions from `in-review` back to `d
 ### Synopsis
 
 ```bash
-> jumbo goal reject --id <goalId> --audit-findings <findings>
+> jumbo goal reject --id <goalId> --audit-findings <findings> [--continue]
 ```
 
 ### Options
@@ -349,11 +355,13 @@ Reject a goal after failed QA review — transitions from `in-review` back to `d
 |--------|-------------|
 | `-i, --id <goalId>` | ID of the goal to reject (required) |
 | `-a, --audit-findings <findings>` | Description of implementation problems that need fixing (required) |
+| `-c, --continue` | Output next-step as a directive instead of informational guidance |
 
 ### Examples
 
 ```bash
 > jumbo goal reject --id goal_abc123 --audit-findings "Missing error handling in API endpoint"
+> jumbo goal reject --id goal_abc123 --audit-findings "Missing tests" --continue
 ```
 
 ---
@@ -389,7 +397,7 @@ Close a goal after codification is complete — transitions from `codifying` to 
 ### Synopsis
 
 ```bash
-> jumbo goal close --id <goalId>
+> jumbo goal close --id <goalId> [--continue]
 ```
 
 ### Options
@@ -397,11 +405,13 @@ Close a goal after codification is complete — transitions from `codifying` to 
 | Option | Description |
 |--------|-------------|
 | `-i, --id <goalId>` | ID of the goal to close (required) |
+| `-c, --continue` | Output next-step as a directive instead of informational guidance |
 
 ### Examples
 
 ```bash
 > jumbo goal close --id goal_abc123
+> jumbo goal close --id goal_abc123 --continue
 ```
 
 ---

--- a/src/presentation/cli/commands/goals/approve/GoalApproveOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/approve/GoalApproveOutputBuilder.ts
@@ -20,10 +20,9 @@ export class GoalApproveOutputBuilder {
    * Build output for successful goal approval.
    * Renders approval result with next steps.
    */
-  buildSuccess(response: QualifyGoalResponse): TerminalOutput {
+  buildSuccess(response: QualifyGoalResponse, continueFlag: boolean = false): TerminalOutput {
     this.builder.reset();
 
-    // Header and success message
     this.builder.addPrompt(
       "# Goal Approved\n" +
       `Goal ID: ${response.goalId}\n` +
@@ -35,10 +34,16 @@ export class GoalApproveOutputBuilder {
       "---"
     );
 
-    // Next steps
-    let nextSteps = "## Next Steps\n" +
-                    "Codify the goal:\n" +
-                    `  Run: jumbo goal codify --id ${response.goalId}`;
+    let nextSteps: string;
+
+    if (continueFlag) {
+      nextSteps = "## Next Steps\n" +
+                  "Codify the goal:\n" +
+                  `  Run: jumbo goal codify --id ${response.goalId}`;
+    } else {
+      nextSteps = "## [Next Phase] Codification\n" +
+                  `To codify the goal: jumbo goal codify --id ${response.goalId}`;
+    }
 
     if (response.nextGoalId) {
       nextSteps += "\n\nAfter closing, the next goal in the queue is:\n" +

--- a/src/presentation/cli/commands/goals/approve/goal.approve.ts
+++ b/src/presentation/cli/commands/goals/approve/goal.approve.ts
@@ -8,7 +8,7 @@
  * See also: goal.qualify (deprecated alias).
  */
 
-import { CommandMetadata } from "../../registry/CommandMetadata.js";
+import { CommandMetadata, CONTINUE_OPTION } from "../../registry/CommandMetadata.js";
 import { IApplicationContainer } from "../../../../../application/host/IApplicationContainer.js";
 import { Renderer } from "../../../rendering/Renderer.js";
 import { GoalApproveOutputBuilder } from "./GoalApproveOutputBuilder.js";
@@ -25,7 +25,7 @@ export const metadata: CommandMetadata = {
       description: "ID of the goal to approve"
     }
   ],
-  options: [],
+  options: [CONTINUE_OPTION],
   examples: [
     {
       command: "jumbo goal approve --id goal_abc123",
@@ -40,10 +40,12 @@ export const metadata: CommandMetadata = {
  * Called by Commander with parsed options
  */
 export async function goalApprove(
-  options: { id: string },
+  options: { id: string; continue?: boolean },
   container: IApplicationContainer
 ) {
   const renderer = Renderer.getInstance();
+
+  const outputBuilder = new GoalApproveOutputBuilder();
 
   try {
     // 1. Execute via controller (delegates to same QualifyGoalController)
@@ -52,13 +54,12 @@ export async function goalApprove(
     });
 
     // 2. Build and render output using builder pattern
-    const outputBuilder = new GoalApproveOutputBuilder();
-    const output = outputBuilder.buildSuccess(response);
-
+    const output = outputBuilder.buildSuccess(response, options.continue === true);
     renderer.info(output.toHumanReadable());
 
   } catch (error) {
-    renderer.error("Failed to approve goal", error instanceof Error ? error : String(error));
+    const errorOutput = outputBuilder.buildFailureError(error instanceof Error ? error : String(error));
+    renderer.error(errorOutput.toHumanReadable());
     process.exit(1);
   }
 }

--- a/src/presentation/cli/commands/goals/close/GoalCloseOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/close/GoalCloseOutputBuilder.ts
@@ -20,10 +20,9 @@ export class GoalCloseOutputBuilder {
    * Build output for successful goal close.
    * Renders close confirmation and optional next goal information.
    */
-  buildSuccess(response: CloseGoalResponse): TerminalOutput {
+  buildSuccess(response: CloseGoalResponse, continueFlag: boolean = false): TerminalOutput {
     this.builder.reset();
 
-    // Header
     this.builder.addPrompt(
       "# Goal Closed\n" +
       `Goal ID: ${response.goalId}\n` +
@@ -32,7 +31,6 @@ export class GoalCloseOutputBuilder {
       "---"
     );
 
-    // Next goal in chain (if exists)
     if (response.nextGoal) {
       this.builder.addPrompt("## Next goal in chain:");
       this.builder.addData({
@@ -40,10 +38,18 @@ export class GoalCloseOutputBuilder {
         objective: response.nextGoal.objective,
         status: response.nextGoal.status,
       });
-      this.builder.addPrompt(
-        "Start the next goal immediately. Run:\n" +
-        `  jumbo goal start --id ${response.nextGoal.goalId}`
-      );
+
+      if (continueFlag) {
+        this.builder.addPrompt(
+          "Start the next goal immediately. Run:\n" +
+          `  jumbo goal start --id ${response.nextGoal.goalId}`
+        );
+      } else {
+        this.builder.addPrompt(
+          "[Next Phase] Implementation\n" +
+          `To start the next goal: jumbo goal start --id ${response.nextGoal.goalId}`
+        );
+      }
     }
 
     return this.builder.build();

--- a/src/presentation/cli/commands/goals/close/goal.close.ts
+++ b/src/presentation/cli/commands/goals/close/goal.close.ts
@@ -5,7 +5,7 @@
  * Transitions goal from 'codifying' to 'done' status and releases the claim.
  */
 
-import { CommandMetadata } from "../../registry/CommandMetadata.js";
+import { CommandMetadata, CONTINUE_OPTION } from "../../registry/CommandMetadata.js";
 import { IApplicationContainer } from "../../../../../application/host/IApplicationContainer.js";
 import { Renderer } from "../../../rendering/Renderer.js";
 import { GoalCloseOutputBuilder } from "./GoalCloseOutputBuilder.js";
@@ -22,7 +22,7 @@ export const metadata: CommandMetadata = {
       description: "ID of the goal to close"
     }
   ],
-  options: [],
+  options: [CONTINUE_OPTION],
   examples: [
     {
       command: "jumbo goal close --id goal_abc123",
@@ -37,10 +37,12 @@ export const metadata: CommandMetadata = {
  * Called by Commander with parsed options
  */
 export async function goalClose(
-  options: { id: string },
+  options: { id: string; continue?: boolean },
   container: IApplicationContainer
 ) {
   const renderer = Renderer.getInstance();
+
+  const outputBuilder = new GoalCloseOutputBuilder();
 
   try {
     // 1. Execute via controller
@@ -49,13 +51,12 @@ export async function goalClose(
     });
 
     // 2. Build and render output using builder pattern
-    const outputBuilder = new GoalCloseOutputBuilder();
-    const output = outputBuilder.buildSuccess(response);
-
+    const output = outputBuilder.buildSuccess(response, options.continue === true);
     renderer.info(output.toHumanReadable());
 
   } catch (error) {
-    renderer.error("Failed to close goal", error instanceof Error ? error : String(error));
+    const errorOutput = outputBuilder.buildFailureError(error instanceof Error ? error : String(error));
+    renderer.error(errorOutput.toHumanReadable());
     process.exit(1);
   }
 }

--- a/src/presentation/cli/commands/goals/commit/GoalCommitOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/commit/GoalCommitOutputBuilder.ts
@@ -19,14 +19,23 @@ export class GoalCommitOutputBuilder {
    * Build output for successful goal commit.
    * Renders success message with next step to start the goal.
    */
-  buildSuccess(goalId: string, status: string): TerminalOutput {
+  buildSuccess(goalId: string, status: string, continueFlag: boolean = false): TerminalOutput {
     this.builder.reset();
     this.builder.addPrompt("✓ Goal committed");
     this.builder.addData({ goalId, status });
-    this.builder.addPrompt(
-      "\n@LLM: Goal refinement is committed and ready to start.\n" +
-      `Run: jumbo goal start --id ${goalId}`
-    );
+
+    if (continueFlag) {
+      this.builder.addPrompt(
+        "\n@LLM: Goal refinement is committed and ready to start.\n" +
+        `Run: jumbo goal start --id ${goalId}`
+      );
+    } else {
+      this.builder.addPrompt(
+        "\n[Next Phase] Implementation\n" +
+        `The goal is now refined and can be started with: jumbo goal start --id ${goalId}`
+      );
+    }
+
     return this.builder.build();
   }
 

--- a/src/presentation/cli/commands/goals/commit/goal.commit.ts
+++ b/src/presentation/cli/commands/goals/commit/goal.commit.ts
@@ -5,7 +5,7 @@
  * Transitions goal from 'in-refinement' to 'refined' status and releases the claim.
  */
 
-import { CommandMetadata } from "../../registry/CommandMetadata.js";
+import { CommandMetadata, CONTINUE_OPTION } from "../../registry/CommandMetadata.js";
 import { IApplicationContainer } from "../../../../../application/host/IApplicationContainer.js";
 import { Renderer } from "../../../rendering/Renderer.js";
 import { GoalCommitOutputBuilder } from "./GoalCommitOutputBuilder.js";
@@ -22,7 +22,7 @@ export const metadata: CommandMetadata = {
       description: "ID of the goal to commit"
     }
   ],
-  options: [],
+  options: [CONTINUE_OPTION],
   examples: [
     {
       command: "jumbo goal commit --id goal_abc123",
@@ -37,7 +37,7 @@ export const metadata: CommandMetadata = {
  * Called by Commander with parsed options
  */
 export async function goalCommit(
-  options: { id: string },
+  options: { id: string; continue?: boolean },
   container: IApplicationContainer
 ) {
   const renderer = Renderer.getInstance();
@@ -50,7 +50,7 @@ export async function goalCommit(
     });
 
     // 2. Build and render output using builder pattern
-    const output = outputBuilder.buildSuccess(response.goalId, response.status);
+    const output = outputBuilder.buildSuccess(response.goalId, response.status, options.continue === true);
     renderer.info(output.toHumanReadable());
 
   } catch (error) {

--- a/src/presentation/cli/commands/goals/reject/GoalRejectOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/reject/GoalRejectOutputBuilder.ts
@@ -20,7 +20,7 @@ export class GoalRejectOutputBuilder {
    * Build output for successful goal rejection.
    * Renders rejection result with review issues and next steps for the implementing agent.
    */
-  buildSuccess(response: RejectGoalResponse): TerminalOutput {
+  buildSuccess(response: RejectGoalResponse, continueFlag: boolean = false): TerminalOutput {
     this.builder.reset();
 
     this.builder.addPrompt(
@@ -35,9 +35,17 @@ export class GoalRejectOutputBuilder {
       "---"
     );
 
-    let nextSteps = "## Next Steps\n" +
-                    "The implementing agent should address the review issues and restart the goal:\n" +
-                    `  Run: jumbo goal start --id ${response.goalId}`;
+    let nextSteps: string;
+
+    if (continueFlag) {
+      nextSteps = "## Next Steps\n" +
+                  "The implementing agent should address the review issues and restart the goal:\n" +
+                  `  Run: jumbo goal start --id ${response.goalId}`;
+    } else {
+      nextSteps = "## [Next Phase] Rework\n" +
+                  "The implementing agent should address the review issues.\n" +
+                  `To restart the goal: jumbo goal start --id ${response.goalId}`;
+    }
 
     if (response.nextGoalId) {
       nextSteps += "\n\nThe next goal in the queue is:\n" +

--- a/src/presentation/cli/commands/goals/reject/goal.reject.ts
+++ b/src/presentation/cli/commands/goals/reject/goal.reject.ts
@@ -6,7 +6,7 @@
  * records review issues, and releases the reviewer's claim.
  */
 
-import { CommandMetadata } from "../../registry/CommandMetadata.js";
+import { CommandMetadata, CONTINUE_OPTION } from "../../registry/CommandMetadata.js";
 import { IApplicationContainer } from "../../../../../application/host/IApplicationContainer.js";
 import { Renderer } from "../../../rendering/Renderer.js";
 import { GoalRejectOutputBuilder } from "./GoalRejectOutputBuilder.js";
@@ -27,7 +27,7 @@ export const metadata: CommandMetadata = {
       description: "Description of implementation problems that need fixing"
     }
   ],
-  options: [],
+  options: [CONTINUE_OPTION],
   examples: [
     {
       command: 'jumbo goal reject --id goal_abc123 --review-issues "Missing error handling in API endpoint"',
@@ -42,7 +42,7 @@ export const metadata: CommandMetadata = {
  * Called by Commander with parsed options
  */
 export async function goalReject(
-  options: { id: string; reviewIssues: string },
+  options: { id: string; reviewIssues: string; continue?: boolean },
   container: IApplicationContainer
 ) {
   const renderer = Renderer.getInstance();
@@ -56,7 +56,7 @@ export async function goalReject(
     });
 
     // 2. Build and render output using builder pattern
-    const output = outputBuilder.buildSuccess(response);
+    const output = outputBuilder.buildSuccess(response, options.continue === true);
     renderer.info(output.toHumanReadable());
 
   } catch (error) {

--- a/src/presentation/cli/commands/goals/submit/GoalSubmitOutputBuilder.ts
+++ b/src/presentation/cli/commands/goals/submit/GoalSubmitOutputBuilder.ts
@@ -20,18 +20,31 @@ export class GoalSubmitOutputBuilder {
    * Build output for successful goal submission.
    * Renders success message with next step to review the goal.
    */
-  buildSuccess(response: SubmitGoalResponse): TerminalOutput {
+  buildSuccess(response: SubmitGoalResponse, continueFlag: boolean = false): TerminalOutput {
     this.builder.reset();
-    this.builder.addPrompt(
-      "# Goal Submitted\n" +
+
+    const header = "# Goal Submitted\n" +
       `Goal ID: ${response.goalId}\n` +
       `Objective: ${response.objective}\n` +
       `Status: ${response.status}\n` +
-      "---\n\n" +
-      "@LLM: Implementation submitted. The goal is now awaiting QA review.\n" +
-      `Run: jumbo goal review --id ${response.goalId}\n` +
-      "---"
-    );
+      "---\n";
+
+    if (continueFlag) {
+      this.builder.addPrompt(
+        header + "\n" +
+        "@LLM: Implementation submitted. The goal is now awaiting QA review.\n" +
+        `Run: jumbo goal review --id ${response.goalId}\n` +
+        "---"
+      );
+    } else {
+      this.builder.addPrompt(
+        header + "\n" +
+        "[Next Phase] QA Review\n" +
+        `The goal is now awaiting QA review. To start the review: jumbo goal review --id ${response.goalId}\n` +
+        "---"
+      );
+    }
+
     return this.builder.build();
   }
 

--- a/src/presentation/cli/commands/goals/submit/goal.submit.ts
+++ b/src/presentation/cli/commands/goals/submit/goal.submit.ts
@@ -5,7 +5,7 @@
  * Transitions goal from 'doing' to 'submitted' status and releases the implementer's claim.
  */
 
-import { CommandMetadata } from "../../registry/CommandMetadata.js";
+import { CommandMetadata, CONTINUE_OPTION } from "../../registry/CommandMetadata.js";
 import { IApplicationContainer } from "../../../../../application/host/IApplicationContainer.js";
 import { Renderer } from "../../../rendering/Renderer.js";
 import { GoalSubmitOutputBuilder } from "./GoalSubmitOutputBuilder.js";
@@ -22,7 +22,7 @@ export const metadata: CommandMetadata = {
       description: "ID of the goal to submit"
     }
   ],
-  options: [],
+  options: [CONTINUE_OPTION],
   examples: [
     {
       command: "jumbo goal submit --id goal_abc123",
@@ -37,7 +37,7 @@ export const metadata: CommandMetadata = {
  * Called by Commander with parsed options
  */
 export async function goalSubmit(
-  options: { id: string },
+  options: { id: string; continue?: boolean },
   container: IApplicationContainer
 ) {
   const renderer = Renderer.getInstance();
@@ -50,7 +50,7 @@ export async function goalSubmit(
     });
 
     // 2. Build and render output using builder pattern
-    const output = outputBuilder.buildSuccess(response);
+    const output = outputBuilder.buildSuccess(response, options.continue === true);
     renderer.info(output.toHumanReadable());
 
   } catch (error) {

--- a/src/presentation/cli/commands/registry/CommandMetadata.ts
+++ b/src/presentation/cli/commands/registry/CommandMetadata.ts
@@ -66,6 +66,15 @@ export interface CommandMetadata {
 }
 
 /**
+ * Shared option for cross-phase transition commands.
+ * When present, next-step output is a directive; when absent, output is informational guidance.
+ */
+export const CONTINUE_OPTION: CommandOption = {
+  flags: "-c, --continue",
+  description: "Output next-step as a directive instead of informational guidance",
+};
+
+/**
  * Registered command with handler
  * Generated at build time by scanning command files
  */

--- a/tests/presentation/cli/commands/goals/close/GoalCloseOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/goals/close/GoalCloseOutputBuilder.test.ts
@@ -1,0 +1,83 @@
+import { GoalCloseOutputBuilder } from "../../../../../../src/presentation/cli/commands/goals/close/GoalCloseOutputBuilder";
+import { CloseGoalResponse } from "../../../../../../src/application/context/goals/close/CloseGoalResponse";
+
+describe("GoalCloseOutputBuilder", () => {
+  let builder: GoalCloseOutputBuilder;
+
+  beforeEach(() => {
+    builder = new GoalCloseOutputBuilder();
+  });
+
+  describe("buildSuccess", () => {
+    const response: CloseGoalResponse = {
+      goalId: "goal_123",
+      objective: "Implement authentication",
+      status: "done",
+    };
+
+    it("should build output without next goal", () => {
+      const output = builder.buildSuccess(response);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal Closed");
+      expect(text).toContain("goal_123");
+      expect(text).toContain("Implement authentication");
+      expect(text).toContain("done");
+    });
+
+    it("should build guidance output with next goal by default (no continue flag)", () => {
+      const responseWithNext: CloseGoalResponse = {
+        ...response,
+        nextGoal: {
+          goalId: "goal_456",
+          objective: "Add logging",
+          status: "refined",
+        },
+      };
+
+      const output = builder.buildSuccess(responseWithNext);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal Closed");
+      expect(text).toContain("Next goal in chain");
+      expect(text).toContain("goal_456");
+      expect(text).toContain("[Next Phase] Implementation");
+      expect(text).toContain("jumbo goal start --id goal_456");
+      expect(text).not.toContain("Start the next goal immediately");
+    });
+
+    it("should build directive output with next goal when continue flag is true", () => {
+      const responseWithNext: CloseGoalResponse = {
+        ...response,
+        nextGoal: {
+          goalId: "goal_456",
+          objective: "Add logging",
+          status: "refined",
+        },
+      };
+
+      const output = builder.buildSuccess(responseWithNext, true);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Start the next goal immediately");
+      expect(text).toContain("jumbo goal start --id goal_456");
+      expect(text).not.toContain("[Next Phase]");
+    });
+  });
+
+  it("should build failure error output", () => {
+    const output = builder.buildFailureError("Something went wrong");
+    const text = output.toHumanReadable();
+
+    expect(text).toContain("Failed to close goal");
+    expect(text).toContain("Something went wrong");
+  });
+
+  it("should build failure error output from Error object", () => {
+    const output = builder.buildFailureError(new Error("Domain error"));
+    const text = output.toHumanReadable();
+
+    expect(text).toContain("Failed to close goal");
+    expect(text).toContain("Domain error");
+  });
+});

--- a/tests/presentation/cli/commands/goals/commit/GoalCommitOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/goals/commit/GoalCommitOutputBuilder.test.ts
@@ -1,0 +1,55 @@
+import { GoalCommitOutputBuilder } from "../../../../../../src/presentation/cli/commands/goals/commit/GoalCommitOutputBuilder";
+
+describe("GoalCommitOutputBuilder", () => {
+  let builder: GoalCommitOutputBuilder;
+
+  beforeEach(() => {
+    builder = new GoalCommitOutputBuilder();
+  });
+
+  describe("buildSuccess", () => {
+    it("should build guidance output by default (no continue flag)", () => {
+      const output = builder.buildSuccess("goal_123", "refined");
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal committed");
+      expect(text).toContain("[Next Phase] Implementation");
+      expect(text).toContain("jumbo goal start --id goal_123");
+      expect(text).not.toContain("@LLM:");
+    });
+
+    it("should build directive output when continue flag is true", () => {
+      const output = builder.buildSuccess("goal_123", "refined", true);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal committed");
+      expect(text).toContain("@LLM:");
+      expect(text).toContain("jumbo goal start --id goal_123");
+      expect(text).not.toContain("[Next Phase]");
+    });
+  });
+
+  it("should build goal not found error output", () => {
+    const output = builder.buildGoalNotFoundError("goal_123");
+    const text = output.toHumanReadable();
+
+    expect(text).toContain("Goal not found");
+    expect(text).toContain("goal_123");
+  });
+
+  it("should build failure error output", () => {
+    const output = builder.buildFailureError("Something went wrong");
+    const text = output.toHumanReadable();
+
+    expect(text).toContain("Failed to commit goal");
+    expect(text).toContain("Something went wrong");
+  });
+
+  it("should build failure error output from Error object", () => {
+    const output = builder.buildFailureError(new Error("Domain error"));
+    const text = output.toHumanReadable();
+
+    expect(text).toContain("Failed to commit goal");
+    expect(text).toContain("Domain error");
+  });
+});

--- a/tests/presentation/cli/commands/goals/reject/GoalRejectOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/goals/reject/GoalRejectOutputBuilder.test.ts
@@ -1,45 +1,47 @@
-import { GoalApproveOutputBuilder } from "../../../../../../src/presentation/cli/commands/goals/approve/GoalApproveOutputBuilder";
-import { QualifyGoalResponse } from "../../../../../../src/application/context/goals/qualify/QualifyGoalResponse";
+import { GoalRejectOutputBuilder } from "../../../../../../src/presentation/cli/commands/goals/reject/GoalRejectOutputBuilder";
+import { RejectGoalResponse } from "../../../../../../src/application/context/goals/reject/RejectGoalResponse";
 
-describe("GoalApproveOutputBuilder", () => {
-  let builder: GoalApproveOutputBuilder;
+describe("GoalRejectOutputBuilder", () => {
+  let builder: GoalRejectOutputBuilder;
 
   beforeEach(() => {
-    builder = new GoalApproveOutputBuilder();
+    builder = new GoalRejectOutputBuilder();
   });
 
   describe("buildSuccess", () => {
-    const response: QualifyGoalResponse = {
+    const response: RejectGoalResponse = {
       goalId: "goal_123",
-      status: "approved",
+      status: "rejected",
       objective: "Implement authentication",
+      reviewIssues: "Missing error handling in API endpoint",
     };
 
     it("should build guidance output by default (no continue flag)", () => {
       const output = builder.buildSuccess(response);
       const text = output.toHumanReadable();
 
-      expect(text).toContain("Goal Approved");
+      expect(text).toContain("Goal Rejected");
       expect(text).toContain("goal_123");
       expect(text).toContain("Implement authentication");
-      expect(text).toContain("approved");
-      expect(text).toContain("[Next Phase] Codification");
-      expect(text).toContain("jumbo goal codify --id goal_123");
-      expect(text).not.toContain("Codify the goal:");
+      expect(text).toContain("rejected");
+      expect(text).toContain("Missing error handling in API endpoint");
+      expect(text).toContain("[Next Phase] Rework");
+      expect(text).toContain("jumbo goal start --id goal_123");
+      expect(text).not.toContain("The implementing agent should address the review issues and restart");
     });
 
     it("should build directive output when continue flag is true", () => {
       const output = builder.buildSuccess(response, true);
       const text = output.toHumanReadable();
 
-      expect(text).toContain("Goal Approved");
-      expect(text).toContain("Codify the goal:");
-      expect(text).toContain("jumbo goal codify --id goal_123");
+      expect(text).toContain("Goal Rejected");
+      expect(text).toContain("The implementing agent should address the review issues and restart");
+      expect(text).toContain("jumbo goal start --id goal_123");
       expect(text).not.toContain("[Next Phase]");
     });
 
     it("should include next goal ID when present", () => {
-      const responseWithNext: QualifyGoalResponse = {
+      const responseWithNext: RejectGoalResponse = {
         ...response,
         nextGoalId: "goal_456",
       };
@@ -55,7 +57,7 @@ describe("GoalApproveOutputBuilder", () => {
     const output = builder.buildFailureError("Something went wrong");
     const text = output.toHumanReadable();
 
-    expect(text).toContain("Failed to approve goal");
+    expect(text).toContain("Failed to reject goal");
     expect(text).toContain("Something went wrong");
   });
 
@@ -63,7 +65,7 @@ describe("GoalApproveOutputBuilder", () => {
     const output = builder.buildFailureError(new Error("Domain error"));
     const text = output.toHumanReadable();
 
-    expect(text).toContain("Failed to approve goal");
+    expect(text).toContain("Failed to reject goal");
     expect(text).toContain("Domain error");
   });
 });

--- a/tests/presentation/cli/commands/goals/submit/GoalSubmitOutputBuilder.test.ts
+++ b/tests/presentation/cli/commands/goals/submit/GoalSubmitOutputBuilder.test.ts
@@ -8,21 +8,36 @@ describe("GoalSubmitOutputBuilder", () => {
     builder = new GoalSubmitOutputBuilder();
   });
 
-  it("should build success output with goal details and next step", () => {
+  describe("buildSuccess", () => {
     const response: SubmitGoalResponse = {
       goalId: "goal_123",
       status: "submitted",
       objective: "Implement authentication",
     };
 
-    const output = builder.buildSuccess(response);
-    const text = output.toHumanReadable();
+    it("should build guidance output by default (no continue flag)", () => {
+      const output = builder.buildSuccess(response);
+      const text = output.toHumanReadable();
 
-    expect(text).toContain("Goal Submitted");
-    expect(text).toContain("goal_123");
-    expect(text).toContain("Implement authentication");
-    expect(text).toContain("submitted");
-    expect(text).toContain("jumbo goal review --id goal_123");
+      expect(text).toContain("Goal Submitted");
+      expect(text).toContain("goal_123");
+      expect(text).toContain("Implement authentication");
+      expect(text).toContain("submitted");
+      expect(text).toContain("[Next Phase] QA Review");
+      expect(text).toContain("jumbo goal review --id goal_123");
+      expect(text).not.toContain("@LLM:");
+    });
+
+    it("should build directive output when continue flag is true", () => {
+      const output = builder.buildSuccess(response, true);
+      const text = output.toHumanReadable();
+
+      expect(text).toContain("Goal Submitted");
+      expect(text).toContain("goal_123");
+      expect(text).toContain("@LLM:");
+      expect(text).toContain("jumbo goal review --id goal_123");
+      expect(text).not.toContain("[Next Phase]");
+    });
   });
 
   it("should build failure error output", () => {


### PR DESCRIPTION
Commit, submit, approve, reject, and close now accept -c/--continue.
Without the flag, next-step output is informational guidance; with it,
output is an imperative directive. This makes phase boundaries explicit
handoff points for multi-agent harnesses.
