### PR TITLE
chore: release 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-04-11
+
+### Changed
+
+- **`goal show` output**: Refined output rendering to align with the design library — updated layout, styling, and symbol usage in `GoalShowOutputBuilder` and `StyleConfig`.
+- **README**: Added reference to the Shared Jumbo Memories repository.
+
 ## [2.11.0] - 2026-04-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [2.11.1] - 2026-04-11

### Changed

- **`goal show` output**: Refined output rendering to align with the design library — updated layout, styling, and symbol usage in `GoalShowOutputBuilder` and `StyleConfig`.
- **README**: Added reference to the Shared Jumbo Memories repository.