### PR TITLE
chore: release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2] - 2026-05-02
+
+### Fixed
+
+- **npm publish workflow**: Added `npm run build` step before `npm test` in the publish workflow so the `NoProjectGuard` integration test (which spawns the compiled `dist/cli.js`) can run during release. Prior releases failed to publish to npm because the test suite errored out before `npm publish`.
+
 ## [3.0.1] - 2026-05-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jumbo-cli",
-  "version": "2.14.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jumbo-cli",
-      "version": "2.14.0",
+      "version": "3.0.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.0.2] - 2026-05-02

### Fixed

- **npm publish workflow**: Added `npm run build` step before `npm test` in the publish workflow so the `NoProjectGuard` integration test (which spawns the compiled `dist/cli.js`) can run during release. Prior releases failed to publish to npm because the test suite errored out before `npm publish`.