### PR TITLE
chore: release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-05-25
+
+### Fixed
+
+- **Release test stability**: Stabilized TUI and daemon tests by removing brittle long-form interactive TUI expectations and using platform-aware path expectations in daemon tests.
+
 ## [3.2.0] - 2026-05-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jumbo-cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jumbo-cli",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
### Fixed

- **Release test stability**: Stabilized TUI and daemon tests by removing brittle long-form interactive TUI expectations and using platform-aware path expectations in daemon tests.