### PR TITLE
chore: release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-05-31
+
+### Added
+
+- **Codex lifecycle hooks**: `jumbo init` and `jumbo evolve` now configure OpenAI Codex with `.codex/hooks.json` containing session-start lifecycle hooks. Hook commands use text output to avoid conflicts with Codex's JSON stdout hook-control envelope parser.
+
 ### Fixed
 
 - **TUI worker daemon output bounds**: Agent subprocess stdout/stderr and daemon event/log payloads are now retained as bounded tails so oversized model output cannot grow worker daemon or TUI memory unboundedly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.3.0] - 2026-05-31

### Added

- **Codex lifecycle hooks**: `jumbo init` and `jumbo evolve` now configure OpenAI Codex with `.codex/hooks.json` containing session-start lifecycle hooks. Hook commands use text output to avoid conflicts with Codex's JSON stdout hook-control envelope parser.

### Fixed

- **TUI worker daemon output bounds**: Agent subprocess stdout/stderr and daemon event/log payloads are now retained as bounded tails so oversized model output cannot grow worker daemon or TUI memory unboundedly.