### PR TITLE
chore: release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-05-31
+
 ### Added
 
 - **Session start backlog preview**: `jumbo session start` now includes a bounded, settings-configurable backlog preview with `goalId`, `title`, `status`, and `createdAt` so agents can see available work while still loading full goal context through follow-up workflow commands.
+
+### Changed
+
+- **Internal**: Decomposed `TuiSubprocessManager` into focused collaborators (`ManagedSubprocess`, `TuiDaemonOutputEventParser`, `TuiSubprocessConfigResolver`, `TuiSubprocessLifecycleEventRecorder`, `TuiSubprocessOutputRingBuffer`, `TuiSubprocessSnapshotMapper`) for improved testability and separation of concerns.
 
 ## [3.3.0] - 2026-05-31
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.4.0] - 2026-05-31

### Added

- **Session start backlog preview**: `jumbo session start` now includes a bounded, settings-configurable backlog preview with `goalId`, `title`, `status`, and `createdAt` so agents can see available work while still loading full goal context through follow-up workflow commands.

### Changed

- **Internal**: Decomposed `TuiSubprocessManager` into focused collaborators (`ManagedSubprocess`, `TuiDaemonOutputEventParser`, `TuiSubprocessConfigResolver`, `TuiSubprocessLifecycleEventRecorder`, `TuiSubprocessOutputRingBuffer`, `TuiSubprocessSnapshotMapper`) for improved testability and separation of concerns.