### PR TITLE
chore: release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-06-01
+
 ### Added
 
 - **Global search command**: Added `jumbo search` for querying the projected global memory search index across components, dependencies, decisions, guidelines, and invariants with grouped text output and structured JSON output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.5.0] - 2026-06-01

### Added

- **Global search command**: Added `jumbo search` for querying the projected global memory search index across components, dependencies, decisions, guidelines, and invariants with grouped text output and structured JSON output.
- **Search index rebuild command**: Added `jumbo index rebuild` for repairing the projected global search index by replaying persisted memory events without rebuilding every Jumbo projection.

### Fixed

- **Top-level command help**: Command-specific help now supports top-level commands such as `jumbo search --help` without requiring a parent/subcommand path.