### PR TITLE
chore: release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-06-02
+
 ### Changed
 
 - **Managed agent files**: `jumbo init`, `jumbo evolve`, and repair flows now generate bootstrap-only agent instruction files from canonical `assets/agent-files` markdown and JSON fragments, while distributing fine-grained managed skills for session bootstrap, lifecycle hooks, command discovery, context maintenance, and correction capture.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.6.0] - 2026-06-02

### Changed

- **Managed agent files**: `jumbo init`, `jumbo evolve`, and repair flows now generate bootstrap-only agent instruction files from canonical `assets/agent-files` markdown and JSON fragments, while distributing fine-grained managed skills for session bootstrap, lifecycle hooks, command discovery, context maintenance, and correction capture.