### PR TITLE
fix(lint): resolve all ESLint errors

### DIFF
--- a/src/application/context/architecture/get/GetArchitectureRequest.ts
+++ b/src/application/context/architecture/get/GetArchitectureRequest.ts
@@ -1,1 +1,1 @@
-export interface GetArchitectureRequest {}
+export type GetArchitectureRequest = Record<string, never>;

--- a/src/application/context/audience-pains/list/GetAudiencePainsRequest.ts
+++ b/src/application/context/audience-pains/list/GetAudiencePainsRequest.ts
@@ -1,1 +1,1 @@
-export interface GetAudiencePainsRequest {}
+export type GetAudiencePainsRequest = Record<string, never>;

--- a/src/application/context/audiences/list/ListAudiencesRequest.ts
+++ b/src/application/context/audiences/list/ListAudiencesRequest.ts
@@ -1,1 +1,1 @@
-export interface ListAudiencesRequest {}
+export type ListAudiencesRequest = Record<string, never>;

--- a/src/application/context/host/workers/view/ViewWorkerRequest.ts
+++ b/src/application/context/host/workers/view/ViewWorkerRequest.ts
@@ -1,1 +1,1 @@
-export interface ViewWorkerRequest {}
+export type ViewWorkerRequest = Record<string, never>;

--- a/src/application/context/invariants/get/GetAllInvariantsRequest.ts
+++ b/src/application/context/invariants/get/GetAllInvariantsRequest.ts
@@ -1,1 +1,1 @@
-export interface GetAllInvariantsRequest {}
+export type GetAllInvariantsRequest = Record<string, never>;

--- a/src/application/context/search/SearchIndexRebuildRequest.ts
+++ b/src/application/context/search/SearchIndexRebuildRequest.ts
@@ -1,1 +1,1 @@
-export interface SearchIndexRebuildRequest {}
+export type SearchIndexRebuildRequest = Record<string, never>;

--- a/src/application/context/sessions/start/SessionStartRequest.ts
+++ b/src/application/context/sessions/start/SessionStartRequest.ts
@@ -4,4 +4,4 @@
  * Currently empty as session start requires no parameters.
  * Exists to follow the controller Request/Response convention.
  */
-export interface SessionStartRequest {}
+export type SessionStartRequest = Record<string, never>;

--- a/src/application/context/sessions/start/StartSessionCommand.ts
+++ b/src/application/context/sessions/start/StartSessionCommand.ts
@@ -1,4 +1,3 @@
-export interface StartSessionCommand {
-  // No properties - session start is parameter-less
-  // Focus is captured at session end as a summary of what was accomplished
-}
+// No properties - session start is parameter-less
+// Focus is captured at session end as a summary of what was accomplished
+export type StartSessionCommand = Record<string, never>;

--- a/src/application/context/telemetry/get/GetTelemetryStatusRequest.ts
+++ b/src/application/context/telemetry/get/GetTelemetryStatusRequest.ts
@@ -1,1 +1,1 @@
-export interface GetTelemetryStatusRequest {}
+export type GetTelemetryStatusRequest = Record<string, never>;

--- a/src/application/context/value-propositions/get/GetValuePropositionsRequest.ts
+++ b/src/application/context/value-propositions/get/GetValuePropositionsRequest.ts
@@ -1,1 +1,1 @@
-export interface GetValuePropositionsRequest {}
+export type GetValuePropositionsRequest = Record<string, never>;

--- a/src/application/context/work/pause/PauseWorkCommand.ts
+++ b/src/application/context/work/pause/PauseWorkCommand.ts
@@ -3,6 +3,5 @@
  * This is a parameterless command that automatically identifies
  * the worker's active goal and pauses it.
  */
-export interface PauseWorkCommand {
-  // Parameterless - worker identity is resolved from IWorkerIdentityReader
-}
+// Parameterless - worker identity is resolved from IWorkerIdentityReader
+export type PauseWorkCommand = Record<string, never>;

--- a/src/application/context/work/pause/PauseWorkRequest.ts
+++ b/src/application/context/work/pause/PauseWorkRequest.ts
@@ -5,4 +5,4 @@
  * The worker's active goal is identified automatically.
  * Exists to follow the controller Request/Response convention.
  */
-export interface PauseWorkRequest {}
+export type PauseWorkRequest = Record<string, never>;

--- a/src/application/context/work/resume/ResumeWorkRequest.ts
+++ b/src/application/context/work/resume/ResumeWorkRequest.ts
@@ -5,4 +5,4 @@
  * The worker's paused goal is identified automatically.
  * Exists to follow the controller Request/Response convention.
  */
-export interface ResumeWorkRequest {}
+export type ResumeWorkRequest = Record<string, never>;

--- a/src/presentation/cli/commands/index/rebuild/index.rebuild.ts
+++ b/src/presentation/cli/commands/index/rebuild/index.rebuild.ts
@@ -24,7 +24,7 @@ export const metadata: CommandMetadata = {
   requiresProject: true,
 };
 
-interface IndexRebuildOptions {}
+type IndexRebuildOptions = Record<string, never>;
 
 export async function indexRebuild(_options: IndexRebuildOptions, container: IApplicationContainer): Promise<void> {
   const renderer = Renderer.getInstance();

--- a/src/presentation/cli/rendering/StyleConfig.ts
+++ b/src/presentation/cli/rendering/StyleConfig.ts
@@ -151,6 +151,7 @@ export const Templates = {
  * Helper to strip ANSI codes for length calculations
  */
 export function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
   const ansiRegex = /\x1B\[[0-?]*[ -/]*[@-~]/g;
   return str.replace(ansiRegex, "");
 }


### PR DESCRIPTION
14 empty interface declarations converted to `type X = Record<string, never>` and one `eslint-disable` added for the intentional ANSI escape regex in `stripAnsi()`.

Lint now passes with 0 errors (50 warnings remain, all `no-unused-vars` on catch parameters). Tests unaffected (2664/2664 pass).