### PR TITLE
chore: release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.1] - 2026-06-08
+
+### Fixed
+
+- **Test stability**: Removed brittle copy/label assertions and oversized snapshot tests for Cockpit stats panel, welcome copy, and HorizontalRule primitive. Refactored `project stats` command handler to eliminate a redundant handler class.
+
 ## [3.7.0] - 2026-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.7.1] - 2026-06-08

### Fixed

- **Test stability**: Removed brittle copy/label assertions and oversized snapshot tests for Cockpit stats panel, welcome copy, and HorizontalRule primitive. Refactored `project stats` command handler to eliminate a redundant handler class.