### PR TITLE
chore: release 3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.2] - 2026-06-08
+
 ### Fixed
 
 - **TUI worker daemons**: Daemon stop controls now wait for real child-process close, prevent duplicate starts while stopping, and escalate process-tree termination after a bounded timeout.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.7.2] - 2026-06-08

### Fixed

- **TUI worker daemons**: Daemon stop controls now wait for real child-process close, prevent duplicate starts while stopping, and escalate process-tree termination after a bounded timeout.
- **Test stability**: Removed a brittle daemon panel copy-count assertion that blocked copy and lifecycle label changes.