### PR TITLE
chore: release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.0] - 2026-06-17
+
 ### Changed
 
 - **`goal show` output**: `jumbo goal show` now includes recorded goal progress entries in both structured JSON output and the human-readable details view.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.10.0] - 2026-06-17

### Changed

- **`goal show` output**: `jumbo goal show` now includes recorded goal progress entries in both structured JSON output and the human-readable details view.