### PR TITLE
chore: release 3.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.12.2] - 2026-07-06
+
 ### Fixed
 
 - **TUI daemon cleanup**: Exiting or interrupting the TUI now routes daemon subprocess shutdown through the launcher, so cleanup is awaited and failures are surfaced instead of relying on fire-and-forget React unmount cleanup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.12.2] - 2026-07-06

### Fixed

- **TUI daemon cleanup**: Exiting or interrupting the TUI now routes daemon subprocess shutdown through the launcher, so cleanup is awaited and failures are surfaced instead of relying on fire-and-forget React unmount cleanup.