### PR TITLE
chore: release 3.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.16.1] - 2026-07-10
+
 ### Fixed
 
 - **TUI daemon reliability**: Cockpit refiner, reviewer, and codifier workers now stream bounded activity and errors while running, retain meaningful outcomes and elapsed-time heartbeats, survive navigation between TUI screens, and stop exactly once on request or application shutdown.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.16.1] - 2026-07-10

### Fixed

- **TUI daemon reliability**: Cockpit refiner, reviewer, and codifier workers now stream bounded activity and errors while running, retain meaningful outcomes and elapsed-time heartbeats, survive navigation between TUI screens, and stop exactly once on request or application shutdown.