### PR TITLE
chore: release 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.18.0] - 2026-07-23
+
 ### Added
 
 - **Bounded relation traversal**: Added `jumbo relations traverse` with deterministic breadth-first traversal, typed root inference, directed graph semantics, depth and edge limits, relation filters, hop-grouped text output, and stable structured output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.18.0] - 2026-07-23

### Added

- **Bounded relation traversal**: Added `jumbo relations traverse` with deterministic breadth-first traversal, typed root inference, directed graph semantics, depth and edge limits, relation filters, hop-grouped text output, and stable structured output.

### Changed

- **Relation list filters**: Expanded `jumbo relations list` with direction, relation type, related entity type, strength, and entity ID filters while preserving active-only status as the default.