### PR TITLE
chore: release 3.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.19.0] - 2026-07-24
+
 ### Added
 
 - **Shortest relation paths**: Added `jumbo relations path` with typed or uniquely inferred endpoints, deterministic bounded breadth-first search, direction and relation filters, provenance-preserving text output, and a stable structured result for connected or disconnected memories.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.19.0] - 2026-07-24

### Added

- **Shortest relation paths**: Added `jumbo relations path` with typed or uniquely inferred endpoints, deterministic bounded breadth-first search, direction and relation filters, provenance-preserving text output, and a stable structured result for connected or disconnected memories.