### PR TITLE
chore: release 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.22.0] - 2026-08-25
+
+### Added
+
+- **Decision show command**: Added `jumbo decision show` to display the complete architectural decision record by ID, with text and JSON output formats.
+
 ### Fixed
 
 - **Goal review verification**: Managed review instructions now discover and run project-supported verification instead of assuming a specific package manager or ecosystem, preventing unrelated review rejections in nonmatching projects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbo-cli",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Memory and Context Orchestration for Coding Agents",
   "keywords": [
     "cli",


### PR DESCRIPTION
## [3.22.0] - 2026-08-25

### Added

- **Decision show command**: Added `jumbo decision show` to display the complete architectural decision record by ID, with text and JSON output formats.

### Fixed

- **Goal review verification**: Managed review instructions now discover and run project-supported verification instead of assuming a specific package manager or ecosystem, preventing unrelated review rejections in nonmatching projects.