### PR TITLE
Fix TTY state isolation in CLI tests

### DIFF
--- a/tests/presentation/cli/commands/decisions/show/decision.show.test.ts
+++ b/tests/presentation/cli/commands/decisions/show/decision.show.test.ts
@@ -77,13 +77,29 @@ describe("decision.show command", () => {
   });
 
   it("defaults non-TTY output to JSON when no format is supplied", async () => {
-    Renderer.reset();
-    handle.mockResolvedValue({ decision });
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
 
-    await decisionShow({ id: "dec_123" }, container as IApplicationContainer);
+    try {
+      Renderer.reset();
+      handle.mockResolvedValue({ decision });
 
-    expect(stdout).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(String(stdout.mock.calls[0][0]))).toEqual(decision);
+      await decisionShow({ id: "dec_123" }, container as IApplicationContainer);
+
+      expect(stdout).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(stdout.mock.calls[0][0]))).toEqual(decision);
+    } finally {
+      Renderer.reset();
+
+      if (isTtyDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", isTtyDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
   });
 
   it("reports unknown IDs only on stderr and sets a non-zero exit code", async () => {

--- a/tests/presentation/cli/commands/project/init/project.init.test.ts
+++ b/tests/presentation/cli/commands/project/init/project.init.test.ts
@@ -191,6 +191,8 @@ describe("project.init command", () => {
 
     if (isTtyDescriptor) {
       Object.defineProperty(process.stdout, "isTTY", isTtyDescriptor);
+    } else {
+      Reflect.deleteProperty(process.stdout, "isTTY");
     }
   });
 


### PR DESCRIPTION
Fixes CI-only TTY state leakage that blocked the 3.22.0 npm publish workflow.